### PR TITLE
feat: Trips API, Blazor trips UI, merge main (Places Plan 2)

### DIFF
--- a/.cursor/rules/github-plan-sync.mdc
+++ b/.cursor/rules/github-plan-sync.mdc
@@ -1,0 +1,19 @@
+---
+description: Sau mỗi milestone plan (superpowers), đồng bộ trạng thái GitHub issues cho repo my-places
+alwaysApply: true
+---
+
+# Đồng bộ GitHub sau milestone plan
+
+Khi **đã hoàn thành** triển khai trong code (và đã cập nhật checklist trong `docs/superpowers/plans/` nếu có), **đừng bỏ qua bước đồng bộ GitHub**:
+
+1. Từ **root repo** chạy: `pwsh ./scripts/github/Sync-Plan3IssuesComplete.ps1`  
+   - Mặc định đóng issue Trips MVP **#11–#14** trên `phucthaidoan/my-places` (lý do `completed` + comment mẫu).  
+   - Dry-run: thêm `-DryRun`.  
+   - Ghi chú lên issue Plan 4 (**#33**) rằng Plan 3 xong: `-AlsoCommentPlan4Issue`.
+
+2. **Xác thực:** `gh auth login` (khuyến nghị) hoặc biến môi trường `GITHUB_TOKEN` (classic PAT, scope `repo`).
+
+3. **Tài liệu:** `scripts/github/README.md` (mục *Đồng bộ sau Plan 3*), `docs/superpowers/github/README.md`.
+
+Nếu sau này có script tương tự cho Plan 4/5…, bổ sung vào `scripts/github/README.md` và cập nhật rule này ngắn gọn.

--- a/.cursor/rules/github-plan-sync.mdc
+++ b/.cursor/rules/github-plan-sync.mdc
@@ -7,6 +7,8 @@ alwaysApply: true
 
 Khi **đã hoàn thành** triển khai trong code (và đã cập nhật checklist trong `docs/superpowers/plans/` nếu có), **đừng bỏ qua bước đồng bộ GitHub**:
 
+0. **Ưu tiên GitHub MCP** (Cursor: server `github` / `project-0-my-places-github`) cho: liệt kê PR, trạng thái merge, đọc PR/issue, v.v. Chỉ dùng `gh` hoặc `GITHUB_TOKEN` + REST khi MCP không khả dụng.
+
 1. Từ **root repo** chạy: `pwsh ./scripts/github/Sync-Plan3IssuesComplete.ps1`  
    - Mặc định đóng issue Trips MVP **#11–#14** trên `phucthaidoan/my-places` (lý do `completed` + comment mẫu).  
    - Dry-run: thêm `-DryRun`.  

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # MCP config (contains secrets)
 .mcp.json
+.cursor/mcp.json
 
 # Claude local settings
 .claude/settings.local.json

--- a/docs/superpowers/github/README.md
+++ b/docs/superpowers/github/README.md
@@ -1,0 +1,43 @@
+# GitHub MCP (Cursor) — tạo issue cho repo `my-places`
+
+Official guide: [Install GitHub MCP Server in Cursor](https://github.com/github/github-mcp-server/blob/main/docs/installation-guides/install-cursor.md).
+
+## Chỉ cho project `my-places` (khuyến nghị)
+
+1. Tạo [Classic PAT](https://github.com/settings/tokens) với scope **`repo`**.
+2. Trong **root repo**, dùng đúng tên file: **`my-places/.cursor/mcp.json`** (tên file là `mcp.json`, **không** phải `.mcp.json` — Cursor không load file sai tên).
+3. Copy nội dung từ [cursor-mcp-github-snippet.json](cursor-mcp-github-snippet.json), thay `YOUR_GITHUB_PAT` bằng PAT (file này đã được `.gitignore` để tránh commit nhầm).
+4. **Restart Cursor**; Settings → MCP: server **`github`** chấm xanh.
+5. **Composer / Chat thường** mới có MCP GitHub; nhiều luồng Agent trong IDE **không** mount MCP nên có thể báo `MCP server does not exist: github` dù cấu hình đúng.
+
+## Bước nhanh (global — merge vào profile)
+
+1. Tạo [Classic PAT](https://github.com/settings/tokens) với scope **`repo`** (tạo issue trong repo private cần quyền này).
+2. Mở **`%USERPROFILE%\.cursor\mcp.json`** (Windows) và **merge** object `github` từ file [cursor-mcp-github-snippet.json](cursor-mcp-github-snippet.json) vào `mcpServers` hiện có (đừng xóa các server khác như `context7`, `grep`, …).
+3. Thay `YOUR_GITHUB_PAT` bằng PAT thật (hoặc dùng UI Cursor: Tools → MCP → github → chỉnh header).
+4. **Khởi động lại Cursor** hoàn toàn; kiểm tra MCP `github` có chấm xanh.
+5. Trong chat/Agent, yêu cầu dùng tool **`issue_write`** với `method: "create"`, `owner`, `repo`, `title`, `body` (xem [GitHub MCP README — issue_write](https://github.com/github/github-mcp-server/blob/main/README.md)).
+
+## Vì sao agent có thể chưa tạo được issue
+
+Nếu Cursor báo **`MCP server does not exist: github`**, nghĩa là bước 2–4 chưa xong hoặc tên server khác (phải đúng key `"github"` trong `mcpServers` trừ khi bạn đổi tên).
+
+## Đồng bộ trạng thái issue (ví dụ sau Plan 3)
+
+Sau khi merge/triển khai xong trong repo, cập nhật issue trên GitHub (đóng #11–#14, v.v.) bằng script:
+
+- [scripts/github/README.md](../../scripts/github/README.md) — mục **Đồng bộ sau Plan 3**
+- Script: `scripts/github/Sync-Plan3IssuesComplete.ps1` (cần `gh` hoặc `GITHUB_TOKEN`)
+
+---
+
+## Milestone `MVP`
+
+GitHub API dùng **số** milestone (`milestone` là number), không phải tên. Có thể:
+
+- Tạo issue **không** gán milestone qua MCP, rồi gán tay trên GitHub, hoặc  
+- Gọi API/GitHub UI để lấy `milestone_number` của **MVP** rồi truyền vào `issue_write`.
+
+## Nội dung issue có sẵn trong repo
+
+Tiêu đề + body mẫu nằm trong [scripts/github/bodies](../../scripts/github/bodies/) và script `gh`: [scripts/github/README.md](../../scripts/github/README.md).

--- a/docs/superpowers/plans/2026-04-18-03-trips-api.md
+++ b/docs/superpowers/plans/2026-04-18-03-trips-api.md
@@ -1,0 +1,280 @@
+# Trips API + Blazor Client — Plan 3
+
+**Trạng thái:** ✅ Hoàn thành (đồng bộ checklist 2026-04-19).
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement Trips CRUD, membership (add/remove `Place` owned by the current user), public share link (`ShareToken` + `TripVisibility`), anonymous read of a shared trip, integration tests, and Blazor WASM UI to manage trips end-to-end.
+
+**Architecture:** Same vertical-slice pattern as Places — one static handler class per endpoint under `src/MyPlaces.Api/Features/Trips/`. DTOs in `MyPlaces.Shared/Trips/`. Authenticated routes use `RequireAuthorization()`; `GET /api/v1/trips/shared/{token}` is **anonymous**. Responses use `Result<T>` where appropriate; `DELETE` returns `204 No Content` on success (match Places `DeletePlace`).
+
+**Tech Stack:** ASP.NET Core 10 Minimal API, EF Core 10 + Npgsql, JWT, xUnit + FluentAssertions + Testcontainers Postgres (existing `TestWebAppFactory`), Blazor WebAssembly.
+
+**Prerequisite (repo hygiene):** Confirm `EndpointExtensions` maps **all** Places endpoints from Plan 2 (`DELETE`, `POST .../copy`, `GET .../nearby` before `{id:guid}`). Some snapshots may only register a subset; Trips UI needs add-place-to-trip against live `POST /api/v1/places` + `GET /api/v1/places`.
+
+**Entities (already in DB — Plan 1):** `Trip`, `TripPlace`, `TripVisibility`, unique filtered index on `ShareToken`. Deleting a `Trip` cascades `TripPlaces` (verify in snapshot — no migration expected for Plan 3).
+
+---
+
+## API contract (MVP spec §5)
+
+| Method | Route | Auth |
+|--------|-------|------|
+| GET | `/api/v1/trips` | Yes |
+| POST | `/api/v1/trips` | Yes |
+| GET | `/api/v1/trips/{id:guid}` | Yes |
+| PUT | `/api/v1/trips/{id:guid}` | Yes |
+| DELETE | `/api/v1/trips/{id:guid}` | Yes |
+| POST | `/api/v1/trips/{id:guid}/places/{placeId:guid}` | Yes |
+| DELETE | `/api/v1/trips/{id:guid}/places/{placeId:guid}` | Yes |
+| POST | `/api/v1/trips/{id:guid}/share` | Yes |
+| GET | `/api/v1/trips/shared/{token}` | **No** |
+
+**Route registration order:** Register `GET /trips/shared/{token}` **before** `GET /trips/{id:guid}` so `shared` is not parsed as a GUID.
+
+---
+
+## File Map
+
+**New — MyPlaces.Shared:**
+- `src/MyPlaces.Shared/Trips/TripVisibility.cs` — enum `Private`, `PublicLink` (string-serialized JSON for API/client)
+- `src/MyPlaces.Shared/Trips/TripRequest.cs` — `CreateTripRequest`, `UpdateTripRequest`
+- `src/MyPlaces.Shared/Trips/TripResponse.cs` — `TripSummaryResponse`, `TripDetailResponse`, `TripPlaceResponse` (place + `AddedAt`), `SharedTripResponse` (same shape as detail or subset — keep one `TripDetailResponse` for owner + shared if convenient)
+
+**New — MyPlaces.Api:**
+- `src/MyPlaces.Api/Features/Trips/CreateTrip.cs`
+- `src/MyPlaces.Api/Features/Trips/GetTrips.cs`
+- `src/MyPlaces.Api/Features/Trips/GetTrip.cs`
+- `src/MyPlaces.Api/Features/Trips/UpdateTrip.cs`
+- `src/MyPlaces.Api/Features/Trips/DeleteTrip.cs`
+- `src/MyPlaces.Api/Features/Trips/AddPlaceToTrip.cs`
+- `src/MyPlaces.Api/Features/Trips/RemovePlaceFromTrip.cs`
+- `src/MyPlaces.Api/Features/Trips/ShareTrip.cs`
+- `src/MyPlaces.Api/Features/Trips/GetSharedTrip.cs`
+- `src/MyPlaces.Api/Features/Trips/TripMappings.cs` (optional static helpers — reuse `CreatePlace.ToResponse` from Places for embedded `PlaceResponse`)
+
+**Modify:**
+- `src/MyPlaces.Api/Common/Extensions/EndpointExtensions.cs` — map Trips routes in correct order
+- `src/MyPlaces.Api/Program.cs` — if needed: `JsonStringEnumConverter` for `TripVisibility` on API JSON options
+
+**New tests:**
+- `tests/MyPlaces.Api.Tests/Features/Trips/CreateTripTests.cs`
+- `tests/MyPlaces.Api.Tests/Features/Trips/GetTripsTests.cs`
+- `tests/MyPlaces.Api.Tests/Features/Trips/GetTripTests.cs`
+- `tests/MyPlaces.Api.Tests/Features/Trips/UpdateTripTests.cs`
+- `tests/MyPlaces.Api.Tests/Features/Trips/DeleteTripTests.cs`
+- `tests/MyPlaces.Api.Tests/Features/Trips/AddRemovePlaceToTripTests.cs`
+- `tests/MyPlaces.Api.Tests/Features/Trips/ShareTripTests.cs`
+- `tests/MyPlaces.Api.Tests/Features/Trips/GetSharedTripTests.cs`
+
+**Blazor — new / modified:**
+- `src/MyPlaces.Client/wwwroot/appsettings.json` + `appsettings.Development.json` — `ApiBaseUrl` (e.g. `https://localhost:7xxx/` or `http://localhost:5000/`)
+- `src/MyPlaces.Client/Program.cs` — named `HttpClient` for API base; optional `AuthorizationMessageHandler` + `IStorageService` / `LocalStorageService` for JWT
+- `src/MyPlaces.Client/Services/AuthState.cs` (or similar) — minimal token hold + login/register calls mirroring `RegisterRequest` / `LoginRequest`
+- `src/MyPlaces.Client/Pages/Login.razor`, `Register.razor` (if not present)
+- `src/MyPlaces.Client/Pages/Trips/TripList.razor` — `@page "/trips"`
+- `src/MyPlaces.Client/Pages/Trips/TripEditor.razor` — `@page "/trips/new"`, `@page "/trips/{TripId:guid}/edit"`
+- `src/MyPlaces.Client/Pages/Trips/TripDetail.razor` — `@page "/trips/{TripId:guid}"` — list places, add/remove (picker from `GET /places`), share button calling `POST .../share`, display copyable public URL
+- `src/MyPlaces.Client/Pages/Trips/SharedTripView.razor` — `@page "/shared/{Token}"` — calls anonymous `GET /api/v1/trips/shared/{token}` (use relative URL from API host; this page may use a separate named `HttpClient` without auth header)
+- `src/MyPlaces.Client/Layout/NavMenu.razor` — link to `/trips`
+
+---
+
+## Behaviour rules (normative)
+
+1. **Ownership:** All authenticated Trip operations require `trip.UserId == currentUser.Id`. Otherwise return `404` (same style as Places — avoid user enumeration).
+
+2. **Add place:** `Place.UserId` must equal `currentUser.Id`. Place must not already be in the trip (`TripPlaces`). Idempotent duplicate → `409 Conflict` or `400` — pick one and document in tests.
+
+3. **Remove place:** Delete `TripPlace` row only; never delete the `Place` entity.
+
+4. **Share token:** URL-safe string (~22–43 chars), cryptographically random (`RandomNumberGenerator`), retry on unique-index collision (extremely rare). `ShareToken` is non-null only when `Visibility == PublicLink`.
+
+5. **`POST /trips/{id}/share` — toggle (MVP):** If trip is `Private`, set `PublicLink` and assign a new `ShareToken`. If already `PublicLink`, set `Private` and clear `ShareToken` (invalidates old links). Response body: `Result<ShareTripResponse>` with `{ Visibility, ShareToken, ShareUrl }` where `ShareUrl` is client-facing path only (e.g. `/shared/{token}`) or full URL if `ApiBaseUrl` known — prefer **relative path** so Blazor can prepend its own origin.
+
+6. **`PUT /trips/{id}`:** Update name, city, country, dates, visibility. When setting `Private`, clear `ShareToken`. When setting `PublicLink` without an existing token, generate one.
+
+7. **`GET /trips/shared/{token}`:** Returns `200` + trip + ordered places (`AddedAt` ascending) only if `Visibility == PublicLink` and `ShareToken == token`. Else `404`. No auth. Do not leak existence of wrong token beyond generic 404.
+
+8. **Detail payload:** Include `PlaceResponse` per place (include `Photos` empty until Plan 5 Photos). Reuse `CreatePlace.ToResponse` internally if `internal` visibility allows, or duplicate mapping in `TripMappings`.
+
+---
+
+## Task 1: Shared DTOs + enum
+
+**Files:** `TripVisibility.cs`, `TripRequest.cs`, `TripResponse.cs` under `src/MyPlaces.Shared/Trips/`.
+
+- [x] Add `TripVisibility` enum aligned with `MyPlaces.Api.Common.Entities.TripVisibility` (same member names).
+
+- [x] `CreateTripRequest(string Name, string City, string? Country, DateTime? StartDate, DateTime? EndDate, TripVisibility Visibility = TripVisibility.Private)`
+
+- [x] `UpdateTripRequest` — same fields as create (all required for replace-style update, consistent with `UpdatePlaceRequest`).
+
+- [x] `TripSummaryResponse(Guid Id, string Name, string City, DateTime? StartDate, DateTime? EndDate, TripVisibility Visibility, int PlaceCount, DateTime CreatedAt)`
+
+- [x] `TripDetailResponse` — summary fields + `List<TripPlaceResponse>` where `TripPlaceResponse(DateTime AddedAt, PlaceResponse Place)`
+
+- [x] `ShareTripResponse(TripVisibility Visibility, string? ShareToken, string? SharePath)` — `SharePath` like `/shared/{token}` when public.
+
+- [x] `dotnet build src/MyPlaces.Shared/MyPlaces.Shared.csproj`
+
+- [x] Commit: `feat(shared): add Trip DTOs`
+
+---
+
+## Task 2: JSON enum + `TripMappings` helper (API)
+
+- [x] Ensure API serializes `TripVisibility` as string (`[JsonConverter(typeof(JsonStringEnumConverter<TripVisibility>))]` on the Shared enum, or global `JsonStringEnumConverter` in `Program.cs`).
+
+- [x] Add `TripMappings.cs` with methods: `ToSummary(Trip)`, `ToDetail(Trip including TripPlaces.Place.Photos)`, `ToSharedDetail` if same as detail.
+
+- [x] Commit: `feat(api): Trip mapping helpers`
+
+---
+
+## Task 3: `CreateTrip` + tests
+
+- [x] Implement `CreateTrip.Handle` — insert `Trip` with `UserId`, default `ShareToken` null unless visibility is `PublicLink` (then generate token).
+
+- [x] Tests: authenticated creates trip; unauthenticated `401`; validate response shape.
+
+- [x] Commit: `feat(api): CreateTrip`
+
+---
+
+## Task 4: `GetTrips` + tests
+
+- [x] List current user’s trips ordered by `CreatedAt` desc; include `PlaceCount` from `TripPlaces.Count`.
+
+- [x] Tests: only own trips; empty list; `401` without auth.
+
+- [x] Commit: `feat(api): GetTrips`
+
+---
+
+## Task 5: `GetTrip` + tests
+
+- [x] Include `TripPlaces` ordered by `AddedAt`, each place with photos.
+
+- [x] Tests: owner OK; other user `404`; unknown id `404`.
+
+- [x] Commit: `feat(api): GetTrip`
+
+---
+
+## Task 6: `UpdateTrip` + tests
+
+- [x] Apply field updates; visibility rules from §Behaviour (clear token when private; generate when switching to public without token).
+
+- [x] Tests: happy path; not found; other user.
+
+- [x] Commit: `feat(api): UpdateTrip`
+
+---
+
+## Task 7: `DeleteTrip` + tests
+
+- [x] Remove trip (cascade removes join rows).
+
+- [x] Tests: `204`; subsequent `GET` `404`; other user `404`.
+
+- [x] Commit: `feat(api): DeleteTrip`
+
+---
+
+## Task 8: `AddPlaceToTrip` + `RemovePlaceFromTrip` + tests
+
+- [x] Add: validate ownership of place and trip; insert `TripPlace` with `AddedAt = UtcNow`.
+
+- [x] Remove: delete join row; `404` if trip/place/membership missing.
+
+- [x] Tests: add twice (second should fail per chosen status code); remove; add other user’s place → `404`.
+
+- [x] Commit: `feat(api): Trip place membership`
+
+---
+
+## Task 9: `ShareTrip` + tests
+
+- [x] Implement toggle per §Behaviour.
+
+- [x] Tests: Private→Public yields token; Public→Private clears token; second toggle restores new token.
+
+- [x] Commit: `feat(api): ShareTrip toggle`
+
+---
+
+## Task 10: `GetSharedTrip` + tests
+
+- [x] Anonymous endpoint; no JWT.
+
+- [x] Tests: factory client **without** `Authorization` header — success when public; `404` when private or bad token.
+
+- [x] Commit: `feat(api): GetSharedTrip`
+
+---
+
+## Task 11: Wire `EndpointExtensions`
+
+- [x] Register routes in order:
+
+```csharp
+// Trips — shared route MUST be before /trips/{id:guid}
+v1.MapGet("/trips/shared/{token}", GetSharedTrip.Handle);
+v1.MapGet("/trips", GetTrips.Handle).RequireAuthorization();
+v1.MapPost("/trips", CreateTrip.Handle).RequireAuthorization();
+v1.MapGet("/trips/{id:guid}", GetTrip.Handle).RequireAuthorization();
+v1.MapPut("/trips/{id:guid}", UpdateTrip.Handle).RequireAuthorization();
+v1.MapDelete("/trips/{id:guid}", DeleteTrip.Handle).RequireAuthorization();
+v1.MapPost("/trips/{id:guid}/places/{placeId:guid}", AddPlaceToTrip.Handle).RequireAuthorization();
+v1.MapDelete("/trips/{id:guid}/places/{placeId:guid}", RemovePlaceFromTrip.Handle).RequireAuthorization();
+v1.MapPost("/trips/{id:guid}/share", ShareTrip.Handle).RequireAuthorization();
+```
+
+- [x] `dotnet build` + `dotnet test tests/MyPlaces.Api.Tests/ -v n` (Docker running for Testcontainers).
+
+- [x] Commit: `feat(api): register Trips endpoints`
+
+---
+
+## Task 12: Blazor — HTTP + auth plumbing
+
+- [x] Add `ApiBaseUrl` to appsettings; register `HttpClient` named `"Api"` with that base address.
+
+- [x] Implement JWT storage (localStorage) + `DelegatingHandler` attaching `Authorization: Bearer` for the named client used by authenticated pages.
+
+- [x] Minimal `Login` / `Register` pages posting to `/api/v1/auth/login` and `/register`; store token; navigate to `/trips`.
+
+- [x] Commit: `feat(client): API HttpClient and auth plumbing`
+
+---
+
+## Task 13: Blazor — Trips UI
+
+- [x] **Trip list:** fetch `GET /trips`, link to detail and “New trip”.
+
+- [x] **Editor:** create + edit forms bound to DTOs; `PUT`/`POST`.
+
+- [x] **Detail:** show places; dropdown or modal listing user’s places from `GET /places`; add/remove buttons; “Share” calls `POST .../share`, show `SharePath` and full URL hint.
+
+- [x] **Shared view:** public page using unauthenticated client to `GET /trips/shared/{token}`.
+
+- [x] Commit: `feat(client): Trips pages and shared trip view`
+
+---
+
+## Verification
+
+- [x] `dotnet test tests/MyPlaces.Api.Tests/ -v n` — all green (CI/local; factory dùng InMemory, không bắt buộc Docker cho suite hiện tại).
+
+- [ ] Manual: run API + Client; register; create places; create trip; add places; toggle share; open shared URL in incognito / second browser profile without login _(khuyến nghị trước release)_.
+
+- [x] CORS: API `AllowedOrigins` hỗ trợ nhiều origin (`;`/`,`) — gồm Blazor dev (`5178` / `7105`) trong `appsettings.Development.json` + fallback trong `Program.cs`.
+
+---
+
+## Notes for Plan 4 (E2E) and Plan 5 (Photos)
+
+After Plan 3, **Plan 4** adds Playwright E2E + MCP verification ([2026-04-18-04-e2e-playwright.md](2026-04-18-04-e2e-playwright.md)).
+
+Trip detail already returns `PlaceResponse.Photos`; **Plan 5 (Photos)** will populate blobs. No contract change expected if `Photos` stays an empty list until then.

--- a/docs/superpowers/plans/2026-04-18-04-e2e-playwright.md
+++ b/docs/superpowers/plans/2026-04-18-04-e2e-playwright.md
@@ -1,0 +1,132 @@
+# E2E tests — Playwright (repo) + Playwright MCP (agent verification)
+
+> **For agentic workers:** Use `superpowers:subagent-driven-development` or `superpowers:executing-plans` task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add a **small, committed** Playwright suite that runs against the real Blazor WASM client + ASP.NET API stack, covering auth and Trips flows (including anonymous shared trip). Document how **Playwright MCP** in Cursor complements this for interactive debugging and pre-merge smoke — without replacing `dotnet test` or the checked-in specs.
+
+**Prerequisite:** [Plan 3 — Trips API + Blazor Client](2026-04-18-03-trips-api.md) implemented enough that: login/register works, `/trips` and shared trip URL work, API and client dev URLs are stable (document in this plan).
+
+**Non-goals:** Full visual regression suite; testing every API edge case (keep those in `MyPlaces.Api.Tests`).
+
+---
+
+## Rationale
+
+| Layer | Tool |
+|-------|------|
+| API contracts, ownership, share rules | `dotnet test` + Testcontainers |
+| CORS, JWT attachment, routing, WASM load | Playwright E2E |
+| Agent “did it work in a browser?” before claiming done | Playwright **MCP** + same `baseURL` as local E2E |
+
+---
+
+## File Map (suggested)
+
+```
+my-places/
+├── e2e/
+│   ├── package.json              # @playwright/test, scripts: test, test:ui
+│   ├── playwright.config.ts      # baseURL, webServer, retries, trace on failure
+│   ├── fixtures/
+│   │   └── auth.ts               # optional: save storageState after register/login
+│   └── specs/
+│       ├── smoke.spec.ts         # app loads, health
+│       ├── auth.spec.ts          # register + login (or login-only if seeded)
+│       ├── trips.spec.ts         # create trip, add place, share, assert link
+│       └── shared-trip.spec.ts   # open /shared/{token} without auth context
+├── docs/superpowers/plans/
+│   └── 2026-04-18-04-e2e-playwright.md   # (this file)
+```
+
+**Optional CI:** `.github/workflows/e2e.yml` — install Node, `npx playwright install --with-deps`, start API + Client (or use `webServer` in config), run `npm test` in `e2e/`.
+
+---
+
+## Configuration conventions
+
+- **`baseURL`:** Blazor dev URL (e.g. `http://localhost:5xxx`) from env `E2E_BASE_URL` with default in `playwright.config.ts`.
+- **API:** Client `appsettings.Development.json` should point API to a running instance; E2E assumes developer runs API + Client **or** `webServer` starts both (harder on one machine — document two-process vs `dotnet run` profiles).
+- **Data:** Prefer **unique emails** per test run (`test+${Date.now()}@example.com`) to avoid collisions unless tests reset DB (not required for MVP E2E if isolation is per email).
+
+---
+
+## Task 1: Scaffold `e2e/` project
+
+- [ ] `cd e2e && npm init -y` (or pnpm) and add `@playwright/test`.
+
+- [ ] `npx playwright install` (document Chromium-only for CI to save time).
+
+- [ ] Add `playwright.config.ts` with `testDir: './specs'`, reasonable `timeout`, `trace: 'on-first-retry'`.
+
+- [ ] Add `.gitignore` under `e2e/` for `test-results/`, `playwright-report/`, `blob-report/`.
+
+- [ ] Root or `e2e/README.md` one paragraph: how to run (`E2E_BASE_URL=... npm test`), prerequisite “API + Client running”.
+
+- [ ] Commit: `chore(e2e): add Playwright scaffold`
+
+---
+
+## Task 2: Smoke spec
+
+- [ ] `smoke.spec.ts`: `page.goto('/')` (or `/login`) — expect HTTP 200 and visible shell (title, nav, or login form).
+
+- [ ] Commit: `test(e2e): smoke spec`
+
+---
+
+## Task 3: Auth spec
+
+- [ ] Flow: register new user → assert redirect or success UI → login (if separate) → assert authenticated marker (e.g. nav shows Trips).
+
+- [ ] Use stable `data-testid` on critical buttons/inputs in Blazor (Plan 3 / follow-up) — prefer testids over fragile CSS.
+
+- [ ] Commit: `test(e2e): auth register and login`
+
+---
+
+## Task 4: Trips + shared link spec
+
+- [ ] Logged-in: create a place (if UI exists) or use API from `request` fixture with saved token — **prefer UI** if Plan 3 includes place creation; otherwise document “seed via API” using `API.request` in Playwright.
+
+- [ ] Create trip, add place to trip, invoke share, read `SharePath` / URL from UI.
+
+- [ ] New browser context **without** storage: open shared URL, assert trip name and at least one place visible.
+
+- [ ] Commit: `test(e2e): trip share flow and anonymous shared view`
+
+---
+
+## Task 5: Playwright MCP (documentation only in repo)
+
+- [ ] In `e2e/README.md` (or this plan §Verification): short list of MCP-driven checks agents should run before claiming Plan 3/4 done (open shared link, screenshot on failure).
+
+- [ ] No MCP config in-repo required (lives in Cursor user MCP settings).
+
+- [ ] Commit: `docs(e2e): document Playwright MCP verification`
+
+---
+
+## Task 6: CI (optional but recommended)
+
+- [ ] GitHub Action job: services or steps to start Postgres if API self-hosts in CI; **simplest path** for MVP: job `workflow_dispatch` only, or skip CI until deploy story exists.
+
+- [ ] If full CI is deferred, document “local + PR manual” in README.
+
+- [ ] Commit (if implemented): `ci: add optional e2e workflow`
+
+---
+
+## Verification
+
+1. With API + Client running locally: `cd e2e && npx playwright test` — all green.
+
+2. `dotnet test` still passes unchanged.
+
+3. Agent checklist: run at least **smoke + shared trip** via Playwright MCP after UI changes.
+
+---
+
+## Relation to later plans
+
+- **Plan 5 (Photos):** extend `trips.spec.ts` or add `photos.spec.ts` when upload UI exists.
+- **Plan 6–7:** add feed/dashboard specs incrementally; keep suite small.

--- a/docs/superpowers/plans/README.md
+++ b/docs/superpowers/plans/README.md
@@ -8,10 +8,11 @@
 |---|------|--------|-------|
 | 1 | [2026-04-18-01-solution-setup.md](2026-04-18-01-solution-setup.md) | ✅ Done | Solution, EF Core entities, Auth (JWT + Google), Result Pattern |
 | 2 | [2026-04-18-02-places-api.md](2026-04-18-02-places-api.md) | ✅ Done | Places API + Blazor Client |
-| 3 | _(chưa viết)_ | ⏳ Pending | Trips API + Blazor Client |
-| 4 | _(chưa viết)_ | ⏳ Pending | Photos (SAS upload flow + client-side resize) |
-| 5 | _(chưa viết)_ | ⏳ Pending | Social (Follow, Search Users, Feed) |
-| 6 | _(chưa viết)_ | ⏳ Pending | Dashboard + Azure Deploy |
+| 3 | [2026-04-18-03-trips-api.md](2026-04-18-03-trips-api.md) | ✅ Done | Trips API + Blazor Client |
+| 4 | [2026-04-18-04-e2e-playwright.md](2026-04-18-04-e2e-playwright.md) | ⏳ Pending (ready) | E2E Playwright (repo) + MCP verification |
+| 5 | _(chưa viết)_ | ⏳ Pending | Photos (SAS upload flow + client-side resize) |
+| 6 | _(chưa viết)_ | ⏳ Pending | Social (Follow, Search Users, Feed) |
+| 7 | _(chưa viết)_ | ⏳ Pending | Dashboard + Azure Deploy |
 
 ## Dependency Order
 
@@ -21,10 +22,12 @@ Plan 1 (Foundation)
 Plan 2 (Places) ← depends on Plan 1
 Plan 3 (Trips)  ← depends on Plan 1 + Plan 2
     ↓
-Plan 4 (Photos) ← depends on Plan 2
-Plan 5 (Social) ← depends on Plan 1
+Plan 4 (E2E Playwright) ← depends on Plan 3 (Blazor flows to test)
     ↓
-Plan 6 (Dashboard + Deploy) ← depends on all above
+Plan 5 (Photos) ← depends on Plan 2
+Plan 6 (Social) ← depends on Plan 1
+    ↓
+Plan 7 (Dashboard + Deploy) ← depends on Plans 1–3, 5–6 (E2E optional but recommended before release)
 ```
 
 ---
@@ -75,16 +78,19 @@ Plan 6 (Dashboard + Deploy) ← depends on all above
 - [x] Commit spec docs vào `docs/superpowers/`
 - [x] Push initial commit
 
+**GitHub — tạo MVP issues (Plan 3–7 + Playwright MVP):** [GitHub MCP + PAT](../github/README.md) (Cursor, tool `issue_write`); fallback [scripts/github/README.md](../../../scripts/github/README.md) (`gh` + milestone `MVP`).
+
 ---
 
 ### 2. Implement Plans
 
 - [x] **Plan 1** — Solution Setup & Core Infrastructure → dùng `superpowers:subagent-driven-development`
 - [x] **Plan 2** — Places API + Blazor Client → PR #32
-- [ ] **Plan 3** — Trips API + Blazor Client _(viết plan sau khi Plan 2 done)_
-- [ ] **Plan 4** — Photos (SAS upload + client-side resize) _(viết plan sau khi Plan 2 done)_
-- [ ] **Plan 5** — Social (Follow, Search, Feed) _(viết plan sau khi Plan 1 done)_
-- [ ] **Plan 6** — Dashboard + Azure Deploy _(viết plan sau khi tất cả done)_
+- [x] **Plan 3** — Trips API + Blazor Client → [2026-04-18-03-trips-api.md](2026-04-18-03-trips-api.md)
+- [ ] **Plan 4** — E2E Playwright + MCP verification → [2026-04-18-04-e2e-playwright.md](2026-04-18-04-e2e-playwright.md) _(bước tiếp theo)_
+- [ ] **Plan 5** — Photos (SAS upload + client-side resize) _(chưa viết plan chi tiết)_
+- [ ] **Plan 6** — Social (Follow, Search, Feed) _(chưa viết plan chi tiết)_
+- [ ] **Plan 7** — Dashboard + Azure Deploy _(chưa viết plan chi tiết)_
 
 ---
 

--- a/scripts/github/README.md
+++ b/scripts/github/README.md
@@ -1,0 +1,97 @@
+# GitHub — MVP issues
+
+## GitHub MCP (Cursor) — ưu tiên nếu đã bật
+
+Cấu hình PAT + merge `mcpServers.github` và tool **`issue_write`**: xem [docs/superpowers/github/README.md](../../docs/superpowers/github/README.md).
+
+---
+
+`gh` có thể không có trên máy; fallback dưới đây dùng **GitHub CLI** + file body có sẵn.
+
+## One-time setup
+
+1. Install [GitHub CLI](https://cli.github.com/) (`winget install GitHub.cli`).
+2. `gh auth login`
+3. In the GitHub repo, ensure milestone **MVP** exists (Issues → Milestones → New milestone).
+
+## Create issues
+
+From repository root:
+
+```powershell
+pwsh ./scripts/github/New-MvpIssues.ps1
+```
+
+Dry run (prints `gh` commands only):
+
+```powershell
+pwsh ./scripts/github/New-MvpIssues.ps1 -DryRun
+```
+
+Without milestone (if you have not created **MVP** yet):
+
+```powershell
+pwsh ./scripts/github/New-MvpIssues.ps1 -Milestone ''
+```
+
+## Đồng bộ sau Plan 3 (đóng issue Trips trên GitHub)
+
+Khi code Plan 3 đã xong trong repo, đóng các issue MVP tương ứng trên GitHub (mặc định **#11–#14** — tiêu đề `[Trips] …`).
+
+Từ thư mục gốc repo:
+
+```powershell
+pwsh ./scripts/github/Sync-Plan3IssuesComplete.ps1
+```
+
+Dry-run (chỉ in việc sẽ làm):
+
+```powershell
+pwsh ./scripts/github/Sync-Plan3IssuesComplete.ps1 -DryRun
+```
+
+Thêm comment lên issue Plan 4 (**#33**) rằng dependency Plan 3 đã xong:
+
+```powershell
+pwsh ./scripts/github/Sync-Plan3IssuesComplete.ps1 -AlsoCommentPlan4Issue
+```
+
+**Yêu cầu:** `gh auth login` (khuyến nghị) hoặc biến môi trường `GITHUB_TOKEN` (classic PAT, scope `repo`).
+
+---
+
+## What gets created
+
+| Title | Body file |
+|-------|-----------|
+| [MVP] Plan 3 — Trips API + Blazor Client | `bodies/mvp-plan3-trips.md` |
+| [MVP] Plan 4 — Playwright E2E in repo + MCP verification (MVP) | `bodies/mvp-plan4-playwright.md` |
+| [MVP] Plan 4 — Optional: GitHub Actions job for Playwright | `bodies/mvp-plan4-playwright-ci.md` |
+| [MVP] Plan 5 — Photos — plan TBD | `bodies/mvp-plan5-photos.md` |
+| [MVP] Plan 6 — Social — plan TBD | `bodies/mvp-plan6-social.md` |
+| [MVP] Plan 7 — Dashboard + Azure deploy — plan TBD | `bodies/mvp-plan7-dashboard-deploy.md` |
+
+Playwright is explicitly **in MVP scope** in the Plan 4 issue body (suite + MCP runbook; CI issue is optional).
+
+## Playwright issues trên GitHub (`phucthaidoan/my-places`)
+
+Đã tạo bằng GitHub MCP (`issue_write`):
+
+| # | URL |
+|---|-----|
+| **33** | https://github.com/phucthaidoan/my-places/issues/33 — Playwright E2E in repo + MCP verification (MVP) |
+| **34** | https://github.com/phucthaidoan/my-places/issues/34 — Optional: GitHub Actions job for Playwright (issue #34 body tham chiếu #33) |
+
+Gán milestone **MVP** trên GitHub UI nếu cần (MCP `milestone` là số, không phải tên).
+
+Tạo lại bằng `gh` (nếu không dùng MCP):
+
+```powershell
+cd c:\Workspaces\Projects\pet\my-places
+gh issue create -R phucthaidoan/my-places --title "[MVP] Plan 4 — Playwright E2E in repo + MCP verification (MVP)" --body-file scripts/github/bodies/mvp-plan4-playwright.md
+gh issue create -R phucthaidoan/my-places --title "[MVP] Plan 4 — Optional: GitHub Actions job for Playwright" --body-file scripts/github/bodies/mvp-plan4-playwright-ci.md
+```
+
+## Manual creation
+
+Copy any file under `bodies/` into a new GitHub issue description and set the title to match the script’s `Title` for that file.

--- a/scripts/github/Sync-Plan3IssuesComplete.ps1
+++ b/scripts/github/Sync-Plan3IssuesComplete.ps1
@@ -1,0 +1,111 @@
+<#
+.SYNOPSIS
+    Đóng các GitHub issue MVP liên quan Plan 3 (Trips) sau khi triển khai xong.
+
+.DESCRIPTION
+    Mặc định đóng **#11–#14** trên `phucthaidoan/my-places` (`[Trips] …`) với
+    `--reason completed` và comment đóng từ `bodies/plan3-issues-close-comment.md`.
+
+    Cần **GitHub CLI** đã đăng nhập (`gh auth login`) — khuyến nghị.
+
+    Nếu không có `gh`, script thử **GITHUB_TOKEN** (classic PAT, scope `repo`) qua REST API:
+    POST comment rồi PATCH `state=closed` + `state_reason=completed`.
+
+.EXAMPLE
+    pwsh ./scripts/github/Sync-Plan3IssuesComplete.ps1 -DryRun
+
+.EXAMPLE
+    pwsh ./scripts/github/Sync-Plan3IssuesComplete.ps1 -AlsoCommentPlan4Issue
+#>
+param(
+    [string] $Owner = "phucthaidoan",
+    [string] $Repo = "my-places",
+    [int[]] $IssueNumbers = @(11, 12, 13, 14),
+    [switch] $AlsoCommentPlan4Issue,
+    [int] $Plan4IssueNumber = 33,
+    [switch] $DryRun
+)
+
+$ErrorActionPreference = "Stop"
+$commentPath = Join-Path $PSScriptRoot "bodies/plan3-issues-close-comment.md"
+$plan4CommentPath = Join-Path $PSScriptRoot "bodies/plan4-unblocked-by-plan3-comment.md"
+
+if (-not (Test-Path $commentPath)) {
+    Write-Error "Missing: $commentPath"
+}
+
+$comment = Get-Content -LiteralPath $commentPath -Raw -Encoding UTF8
+$full = "$Owner/$Repo"
+
+function Add-IssueCommentRest {
+    param([int] $Number, [string] $Body)
+    $token = $env:GITHUB_TOKEN
+    if (-not $token) { throw "GITHUB_TOKEN not set" }
+    $headers = @{
+        Authorization          = "Bearer $token"
+        Accept                 = "application/vnd.github+json"
+        "X-GitHub-Api-Version" = "2022-11-28"
+    }
+    $uri = "https://api.github.com/repos/$Owner/$Repo/issues/$Number/comments"
+    $json = (@{ body = $Body } | ConvertTo-Json -Compress)
+    Invoke-RestMethod -Uri $uri -Method Post -Headers $headers -Body $json -ContentType "application/json; charset=utf-8"
+}
+
+function Close-IssueRest {
+    param([int] $Number)
+    $token = $env:GITHUB_TOKEN
+    if (-not $token) { throw "GITHUB_TOKEN not set" }
+    $headers = @{
+        Authorization          = "Bearer $token"
+        Accept                 = "application/vnd.github+json"
+        "X-GitHub-Api-Version" = "2022-11-28"
+    }
+    $uri = "https://api.github.com/repos/$Owner/$Repo/issues/$Number"
+    $json = (@{ state = "closed"; state_reason = "completed" } | ConvertTo-Json -Compress)
+    Invoke-RestMethod -Uri $uri -Method Patch -Headers $headers -Body $json -ContentType "application/json; charset=utf-8"
+}
+
+foreach ($n in $IssueNumbers) {
+    if ($DryRun) {
+        Write-Host "DRY RUN: close #$n on $full (comment length: $($comment.Length))"
+        continue
+    }
+
+    if (Get-Command gh -ErrorAction SilentlyContinue) {
+        gh issue close $n -R $full --reason completed --comment $comment
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "gh issue close failed for #$n"
+        }
+    }
+    elseif ($env:GITHUB_TOKEN) {
+        Add-IssueCommentRest -Number $n -Body $comment
+        Close-IssueRest -Number $n
+    }
+    else {
+        Write-Error "Install GitHub CLI (winget install GitHub.cli) and run 'gh auth login', or set GITHUB_TOKEN (classic PAT with repo scope)."
+    }
+
+    Start-Sleep -Milliseconds 400
+}
+
+if ($AlsoCommentPlan4Issue) {
+    if (-not (Test-Path $plan4CommentPath)) {
+        Write-Warning "Skip Plan 4 comment: missing $plan4CommentPath"
+    }
+    elseif ($DryRun) {
+        Write-Host "DRY RUN: add comment to #$Plan4IssueNumber"
+    }
+    elseif (Get-Command gh -ErrorAction SilentlyContinue) {
+        $c = Get-Content -LiteralPath $plan4CommentPath -Raw -Encoding UTF8
+        gh issue comment $Plan4IssueNumber -R $full --body $c
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "gh issue comment failed for #$Plan4IssueNumber"
+        }
+    }
+    elseif ($env:GITHUB_TOKEN) {
+        $c = Get-Content -LiteralPath $plan4CommentPath -Raw -Encoding UTF8
+        Add-IssueCommentRest -Number $Plan4IssueNumber -Body $c
+    }
+}
+
+Write-Host "Done. Target issues: $($IssueNumbers -join ', ') on $full"

--- a/scripts/github/bodies/mvp-plan3-trips.md
+++ b/scripts/github/bodies/mvp-plan3-trips.md
@@ -1,0 +1,25 @@
+## Summary
+
+Implement **Plan 3 — Trips API + Blazor Client** per the superpowers plan.
+
+## Plan document
+
+- `docs/superpowers/plans/2026-04-18-03-trips-api.md`
+
+## MVP spec
+
+- Trips CRUD, add/remove places (owner only), share token + public `GET /trips/shared/{token}`, Blazor UI (list / edit / detail / shared view), minimal auth plumbing for the client.
+
+## Prerequisites
+
+- Confirm `EndpointExtensions` registers **all** Places routes from Plan 2 (including delete, copy, nearby) if not already present — needed for “add place to trip” UX.
+
+## Agent workflow
+
+- Prefer `superpowers:subagent-driven-development` (or `executing-plans`) and check off tasks in the plan file.
+
+## Acceptance
+
+- [x] All Plan 3 tasks in the plan doc completed (or consciously deferred with follow-up issue).
+- [x] `dotnet test` passes (API suite; factory dùng InMemory — Docker optional).
+- [ ] Manual: create trip, add place, share link, open shared URL without auth _(recommended before release)_.

--- a/scripts/github/bodies/plan3-issues-close-comment.md
+++ b/scripts/github/bodies/plan3-issues-close-comment.md
@@ -1,0 +1,9 @@
+Đóng issue: **Plan 3 — Trips API + Blazor Client** đã triển khai trong repo.
+
+- Plan: `docs/superpowers/plans/2026-04-18-03-trips-api.md` (checklist đã đồng bộ).
+- API: CRUD trips, thêm/xóa place trong trip, share toggle + `GET /api/v1/trips/shared/{token}` (anonymous), integration tests.
+- Client: `ApiBaseUrl`, JWT (localStorage + `DelegatingHandler`), Login/Register, Trips list/editor/detail/shared view.
+- Places (prerequisite Plan 2): `DELETE`, `POST …/copy`, `GET …/nearby` đã đăng ký đúng thứ tự.
+- Auth: `PostConfigure<AuthenticationOptions>` để **JWT Bearer** là scheme mặc định (Identity không còn override cookie).
+
+Nếu cần rà soát PR/commit, xem lịch sử merge gần nhất trên nhánh chính / PR liên quan Plan 3.

--- a/scripts/github/bodies/plan4-unblocked-by-plan3-comment.md
+++ b/scripts/github/bodies/plan4-unblocked-by-plan3-comment.md
@@ -1,0 +1,1 @@
+**Plan 3 dependency met:** Trips API + Blazor (list / editor / detail / shared view) và auth plumbing đã có trong repo; có thể bắt đầu triển khai Playwright theo `docs/superpowers/plans/2026-04-18-04-e2e-playwright.md`.

--- a/src/MyPlaces.Api/Common/Extensions/AuthExtensions.cs
+++ b/src/MyPlaces.Api/Common/Extensions/AuthExtensions.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 
@@ -28,6 +29,13 @@ public static class AuthExtensions
                     ClockSkew = TimeSpan.Zero
                 };
             });
+
+        // AddIdentity sets DefaultAuthenticateScheme to cookies; API uses Bearer JWT only.
+        services.PostConfigure<AuthenticationOptions>(o =>
+        {
+            o.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+            o.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+        });
 
         services.AddAuthorization();
         return services;

--- a/src/MyPlaces.Api/Common/Extensions/EndpointExtensions.cs
+++ b/src/MyPlaces.Api/Common/Extensions/EndpointExtensions.cs
@@ -1,5 +1,6 @@
 using MyPlaces.Api.Features.Auth;
 using MyPlaces.Api.Features.Places;
+using MyPlaces.Api.Features.Trips;
 
 namespace MyPlaces.Api.Common.Extensions;
 
@@ -15,11 +16,25 @@ public static class EndpointExtensions
         v1.MapPost("/auth/google", GoogleLogin.Handle);
         v1.MapPost("/auth/refresh-token", RefreshToken.Handle);
 
-        // Places
+        // Places — /places/nearby before /places/{id:guid}
         v1.MapPost("/places", CreatePlace.Handle).RequireAuthorization();
         v1.MapGet("/places", GetPlaces.Handle).RequireAuthorization();
+        v1.MapGet("/places/nearby", GetNearbyPlaces.Handle).RequireAuthorization();
         v1.MapGet("/places/{id:guid}", GetPlace.Handle).RequireAuthorization();
         v1.MapPut("/places/{id:guid}", UpdatePlace.Handle).RequireAuthorization();
+        v1.MapDelete("/places/{id:guid}", DeletePlace.Handle).RequireAuthorization();
+        v1.MapPost("/places/{id:guid}/copy", CopyPlace.Handle).RequireAuthorization();
+
+        // Trips — shared route before /trips/{id:guid}
+        v1.MapGet("/trips/shared/{token}", GetSharedTrip.Handle);
+        v1.MapGet("/trips", GetTrips.Handle).RequireAuthorization();
+        v1.MapPost("/trips", CreateTrip.Handle).RequireAuthorization();
+        v1.MapGet("/trips/{id:guid}", GetTrip.Handle).RequireAuthorization();
+        v1.MapPut("/trips/{id:guid}", UpdateTrip.Handle).RequireAuthorization();
+        v1.MapDelete("/trips/{id:guid}", DeleteTrip.Handle).RequireAuthorization();
+        v1.MapPost("/trips/{id:guid}/places/{placeId:guid}", AddPlaceToTrip.Handle).RequireAuthorization();
+        v1.MapDelete("/trips/{id:guid}/places/{placeId:guid}", RemovePlaceFromTrip.Handle).RequireAuthorization();
+        v1.MapPost("/trips/{id:guid}/share", ShareTrip.Handle).RequireAuthorization();
 
         return app;
     }

--- a/src/MyPlaces.Api/Features/Places/CopyPlace.cs
+++ b/src/MyPlaces.Api/Features/Places/CopyPlace.cs
@@ -1,5 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using MyPlaces.Api.Common;
+using MyPlaces.Api.Common.Entities;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Places;
+
 namespace MyPlaces.Api.Features.Places;
+
 public static class CopyPlace
 {
-    public static IResult Handle(Guid id) => Results.StatusCode(501);
+    public static async Task<IResult> Handle(
+        Guid id,
+        AppDbContext db,
+        ICurrentUser currentUser,
+        CancellationToken ct)
+    {
+        var source = await db.Places
+            .FirstOrDefaultAsync(p => p.Id == id, ct);
+
+        if (source is null)
+            return Results.NotFound();
+
+        var copy = new Place
+        {
+            UserId = currentUser.Id,
+            Name = source.Name,
+            Address = source.Address,
+            City = source.City,
+            Country = source.Country,
+            Latitude = source.Latitude,
+            Longitude = source.Longitude,
+            Note = source.Note,
+            SourcePlaceId = source.Id
+        };
+
+        db.Places.Add(copy);
+        await db.SaveChangesAsync(ct);
+
+        await db.Entry(copy).Collection(p => p.Photos).LoadAsync(ct);
+        return Results.Ok(Result<PlaceResponse>.Success(CreatePlace.ToResponse(copy)));
+    }
 }

--- a/src/MyPlaces.Api/Features/Places/GetNearbyPlaces.cs
+++ b/src/MyPlaces.Api/Features/Places/GetNearbyPlaces.cs
@@ -1,5 +1,62 @@
+using Microsoft.EntityFrameworkCore;
+using MyPlaces.Api.Common;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Places;
+
 namespace MyPlaces.Api.Features.Places;
+
 public static class GetNearbyPlaces
 {
-    public static IResult Handle() => Results.StatusCode(501);
+    private const double EarthRadiusKm = 6371.0;
+
+    public static async Task<IResult> Handle(
+        AppDbContext db,
+        ICurrentUser currentUser,
+        double? lat,
+        double? lng,
+        double radiusKm = 5,
+        CancellationToken ct = default)
+    {
+        if (lat is null || lng is null)
+            return Results.BadRequest(Result<List<PlaceSummaryResponse>>.Failure("lat and lng are required"));
+
+        var candidates = await db.Places
+            .Include(p => p.Photos)
+            .Where(p => p.UserId == currentUser.Id && p.Latitude != null && p.Longitude != null)
+            .ToListAsync(ct);
+
+        var nearby = candidates
+            .Select(p => new
+            {
+                Place = p,
+                DistanceKm = HaversineKm(lat.Value, lng.Value, p.Latitude!.Value, p.Longitude!.Value)
+            })
+            .Where(x => x.DistanceKm <= radiusKm)
+            .OrderBy(x => x.DistanceKm)
+            .Select(x => new PlaceSummaryResponse(
+                x.Place.Id,
+                x.Place.Name,
+                x.Place.City,
+                x.Place.Country,
+                x.Place.Latitude,
+                x.Place.Longitude,
+                x.Place.CreatedAt,
+                x.Place.Photos.OrderBy(ph => ph.SortOrder).Select(ph => ph.PhotoUrl).FirstOrDefault()
+            ))
+            .ToList();
+
+        return Results.Ok(Result<List<PlaceSummaryResponse>>.Success(nearby));
+    }
+
+    private static double HaversineKm(double lat1, double lon1, double lat2, double lon2)
+    {
+        var dLat = ToRad(lat2 - lat1);
+        var dLon = ToRad(lon2 - lon1);
+        var a = Math.Sin(dLat / 2) * Math.Sin(dLat / 2)
+              + Math.Cos(ToRad(lat1)) * Math.Cos(ToRad(lat2))
+              * Math.Sin(dLon / 2) * Math.Sin(dLon / 2);
+        return EarthRadiusKm * 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
+    }
+
+    private static double ToRad(double deg) => deg * Math.PI / 180.0;
 }

--- a/src/MyPlaces.Api/Features/Trips/AddPlaceToTrip.cs
+++ b/src/MyPlaces.Api/Features/Trips/AddPlaceToTrip.cs
@@ -1,0 +1,49 @@
+using Microsoft.EntityFrameworkCore;
+using MyPlaces.Api.Common;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Trips;
+
+namespace MyPlaces.Api.Features.Trips;
+
+public static class AddPlaceToTrip
+{
+    public static async Task<IResult> Handle(
+        Guid id,
+        Guid placeId,
+        AppDbContext db,
+        ICurrentUser currentUser,
+        CancellationToken ct)
+    {
+        var trip = await db.Trips
+            .FirstOrDefaultAsync(t => t.Id == id && t.UserId == currentUser.Id, ct);
+
+        if (trip is null)
+            return Results.NotFound();
+
+        var place = await db.Places
+            .FirstOrDefaultAsync(p => p.Id == placeId && p.UserId == currentUser.Id, ct);
+
+        if (place is null)
+            return Results.NotFound();
+
+        var exists = await db.TripPlaces.AnyAsync(tp => tp.TripId == id && tp.PlaceId == placeId, ct);
+        if (exists)
+            return Results.Conflict();
+
+        db.TripPlaces.Add(new()
+        {
+            TripId = id,
+            PlaceId = placeId,
+            AddedAt = DateTime.UtcNow
+        });
+
+        await db.SaveChangesAsync(ct);
+
+        await db.Entry(trip).Collection(t => t.TripPlaces).Query()
+            .Include(tp => tp.Place)
+            .ThenInclude(p => p.Photos)
+            .LoadAsync(ct);
+
+        return Results.Ok(Result<TripDetailResponse>.Success(TripMappings.ToDetail(trip)));
+    }
+}

--- a/src/MyPlaces.Api/Features/Trips/CreateTrip.cs
+++ b/src/MyPlaces.Api/Features/Trips/CreateTrip.cs
@@ -1,0 +1,40 @@
+using MyPlaces.Api.Common;
+using MyPlaces.Api.Common.Entities;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Trips;
+using E = MyPlaces.Api.Common.Entities;
+
+namespace MyPlaces.Api.Features.Trips;
+
+public static class CreateTrip
+{
+    public static async Task<IResult> Handle(
+        CreateTripRequest req,
+        AppDbContext db,
+        ICurrentUser currentUser,
+        CancellationToken ct)
+    {
+        string? shareToken = null;
+        var visibility = TripMappings.ToEntity(req.Visibility);
+        if (visibility == E.TripVisibility.PublicLink)
+            shareToken = await TripShareToken.GenerateUniqueAsync(db, ct);
+
+        var trip = new Trip
+        {
+            UserId = currentUser.Id,
+            Name = req.Name,
+            City = req.City,
+            Country = req.Country,
+            StartDate = req.StartDate,
+            EndDate = req.EndDate,
+            Visibility = visibility,
+            ShareToken = shareToken
+        };
+
+        db.Trips.Add(trip);
+        await db.SaveChangesAsync(ct);
+
+        await db.Entry(trip).Collection(t => t.TripPlaces).LoadAsync(ct);
+        return Results.Ok(Result<TripDetailResponse>.Success(TripMappings.ToDetail(trip)));
+    }
+}

--- a/src/MyPlaces.Api/Features/Trips/DeleteTrip.cs
+++ b/src/MyPlaces.Api/Features/Trips/DeleteTrip.cs
@@ -1,9 +1,9 @@
 using Microsoft.EntityFrameworkCore;
 using MyPlaces.Api.Common;
 
-namespace MyPlaces.Api.Features.Places;
+namespace MyPlaces.Api.Features.Trips;
 
-public static class DeletePlace
+public static class DeleteTrip
 {
     public static async Task<IResult> Handle(
         Guid id,
@@ -11,13 +11,13 @@ public static class DeletePlace
         ICurrentUser currentUser,
         CancellationToken ct)
     {
-        var place = await db.Places
-            .FirstOrDefaultAsync(p => p.Id == id && p.UserId == currentUser.Id, ct);
+        var trip = await db.Trips
+            .FirstOrDefaultAsync(t => t.Id == id && t.UserId == currentUser.Id, ct);
 
-        if (place is null)
+        if (trip is null)
             return Results.NotFound();
 
-        db.Places.Remove(place);
+        db.Trips.Remove(trip);
         await db.SaveChangesAsync(ct);
 
         return Results.NoContent();

--- a/src/MyPlaces.Api/Features/Trips/GetSharedTrip.cs
+++ b/src/MyPlaces.Api/Features/Trips/GetSharedTrip.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using MyPlaces.Api.Common;
+using MyPlaces.Api.Common.Entities;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Trips;
+using E = MyPlaces.Api.Common.Entities;
+
+namespace MyPlaces.Api.Features.Trips;
+
+public static class GetSharedTrip
+{
+    public static async Task<IResult> Handle(
+        string token,
+        AppDbContext db,
+        CancellationToken ct)
+    {
+        var trip = await db.Trips
+            .AsNoTracking()
+            .Include(t => t.TripPlaces)
+            .ThenInclude(tp => tp.Place)
+            .ThenInclude(p => p.Photos)
+            .FirstOrDefaultAsync(
+                t => t.ShareToken == token && t.Visibility == E.TripVisibility.PublicLink,
+                ct);
+
+        if (trip is null)
+            return Results.NotFound();
+
+        return Results.Ok(Result<TripDetailResponse>.Success(TripMappings.ToDetail(trip)));
+    }
+}

--- a/src/MyPlaces.Api/Features/Trips/GetTrip.cs
+++ b/src/MyPlaces.Api/Features/Trips/GetTrip.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using MyPlaces.Api.Common;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Trips;
+
+namespace MyPlaces.Api.Features.Trips;
+
+public static class GetTrip
+{
+    public static async Task<IResult> Handle(
+        Guid id,
+        AppDbContext db,
+        ICurrentUser currentUser,
+        CancellationToken ct)
+    {
+        var trip = await db.Trips
+            .Include(t => t.TripPlaces)
+            .ThenInclude(tp => tp.Place)
+            .ThenInclude(p => p.Photos)
+            .FirstOrDefaultAsync(t => t.Id == id && t.UserId == currentUser.Id, ct);
+
+        if (trip is null)
+            return Results.NotFound();
+
+        return Results.Ok(Result<TripDetailResponse>.Success(TripMappings.ToDetail(trip)));
+    }
+}

--- a/src/MyPlaces.Api/Features/Trips/GetTrips.cs
+++ b/src/MyPlaces.Api/Features/Trips/GetTrips.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using MyPlaces.Api.Common;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Trips;
+
+namespace MyPlaces.Api.Features.Trips;
+
+public static class GetTrips
+{
+    public static async Task<IResult> Handle(
+        AppDbContext db,
+        ICurrentUser currentUser,
+        CancellationToken ct)
+    {
+        var trips = await db.Trips
+            .Include(t => t.TripPlaces)
+            .Where(t => t.UserId == currentUser.Id)
+            .OrderByDescending(t => t.CreatedAt)
+            .ToListAsync(ct);
+
+        var list = trips.Select(TripMappings.ToSummary).ToList();
+        return Results.Ok(Result<List<TripSummaryResponse>>.Success(list));
+    }
+}

--- a/src/MyPlaces.Api/Features/Trips/RemovePlaceFromTrip.cs
+++ b/src/MyPlaces.Api/Features/Trips/RemovePlaceFromTrip.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using MyPlaces.Api.Common;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Trips;
+
+namespace MyPlaces.Api.Features.Trips;
+
+public static class RemovePlaceFromTrip
+{
+    public static async Task<IResult> Handle(
+        Guid id,
+        Guid placeId,
+        AppDbContext db,
+        ICurrentUser currentUser,
+        CancellationToken ct)
+    {
+        var trip = await db.Trips
+            .FirstOrDefaultAsync(t => t.Id == id && t.UserId == currentUser.Id, ct);
+
+        if (trip is null)
+            return Results.NotFound();
+
+        var link = await db.TripPlaces
+            .FirstOrDefaultAsync(tp => tp.TripId == id && tp.PlaceId == placeId, ct);
+
+        if (link is null)
+            return Results.NotFound();
+
+        db.TripPlaces.Remove(link);
+        await db.SaveChangesAsync(ct);
+
+        await db.Entry(trip).Collection(t => t.TripPlaces).Query()
+            .Include(tp => tp.Place)
+            .ThenInclude(p => p.Photos)
+            .LoadAsync(ct);
+
+        return Results.Ok(Result<TripDetailResponse>.Success(TripMappings.ToDetail(trip)));
+    }
+}

--- a/src/MyPlaces.Api/Features/Trips/ShareTrip.cs
+++ b/src/MyPlaces.Api/Features/Trips/ShareTrip.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore;
+using MyPlaces.Api.Common;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Trips;
+using E = MyPlaces.Api.Common.Entities;
+
+namespace MyPlaces.Api.Features.Trips;
+
+public static class ShareTrip
+{
+    public static async Task<IResult> Handle(
+        Guid id,
+        AppDbContext db,
+        ICurrentUser currentUser,
+        CancellationToken ct)
+    {
+        var trip = await db.Trips
+            .FirstOrDefaultAsync(t => t.Id == id && t.UserId == currentUser.Id, ct);
+
+        if (trip is null)
+            return Results.NotFound();
+
+        if (trip.Visibility == E.TripVisibility.Private)
+        {
+            trip.Visibility = E.TripVisibility.PublicLink;
+            trip.ShareToken = await TripShareToken.GenerateUniqueAsync(db, ct);
+        }
+        else
+        {
+            trip.Visibility = E.TripVisibility.Private;
+            trip.ShareToken = null;
+        }
+
+        await db.SaveChangesAsync(ct);
+
+        var sharePath = trip.Visibility == E.TripVisibility.PublicLink && trip.ShareToken is not null
+            ? $"/shared/{trip.ShareToken}"
+            : null;
+
+        var body = new ShareTripResponse(
+            TripMappings.ToShared(trip.Visibility),
+            trip.ShareToken,
+            sharePath);
+
+        return Results.Ok(Result<ShareTripResponse>.Success(body));
+    }
+}

--- a/src/MyPlaces.Api/Features/Trips/TripMappings.cs
+++ b/src/MyPlaces.Api/Features/Trips/TripMappings.cs
@@ -1,0 +1,55 @@
+using MyPlaces.Api.Common.Entities;
+using MyPlaces.Api.Features.Places;
+using MyPlaces.Shared.Trips;
+using SharedTripVisibility = MyPlaces.Shared.Trips.TripVisibility;
+using E = MyPlaces.Api.Common.Entities;
+
+namespace MyPlaces.Api.Features.Trips;
+
+internal static class TripMappings
+{
+    internal static SharedTripVisibility ToShared(E.TripVisibility v) => v switch
+    {
+        E.TripVisibility.Private => SharedTripVisibility.Private,
+        E.TripVisibility.PublicLink => SharedTripVisibility.PublicLink,
+        _ => throw new ArgumentOutOfRangeException(nameof(v))
+    };
+
+    internal static E.TripVisibility ToEntity(SharedTripVisibility v) => v switch
+    {
+        SharedTripVisibility.Private => E.TripVisibility.Private,
+        SharedTripVisibility.PublicLink => E.TripVisibility.PublicLink,
+        _ => throw new ArgumentOutOfRangeException(nameof(v))
+    };
+
+    internal static TripSummaryResponse ToSummary(Trip trip) => new(
+        trip.Id,
+        trip.Name,
+        trip.City,
+        trip.StartDate,
+        trip.EndDate,
+        ToShared(trip.Visibility),
+        trip.TripPlaces.Count,
+        trip.CreatedAt
+    );
+
+    internal static TripDetailResponse ToDetail(Trip trip)
+    {
+        var ordered = trip.TripPlaces
+            .OrderBy(tp => tp.AddedAt)
+            .Select(tp => new TripPlaceResponse(tp.AddedAt, CreatePlace.ToResponse(tp.Place)))
+            .ToList();
+
+        return new TripDetailResponse(
+            trip.Id,
+            trip.Name,
+            trip.City,
+            trip.Country,
+            trip.StartDate,
+            trip.EndDate,
+            ToShared(trip.Visibility),
+            trip.CreatedAt,
+            ordered
+        );
+    }
+}

--- a/src/MyPlaces.Api/Features/Trips/TripShareToken.cs
+++ b/src/MyPlaces.Api/Features/Trips/TripShareToken.cs
@@ -1,0 +1,35 @@
+using System.Security.Cryptography;
+using Microsoft.EntityFrameworkCore;
+using MyPlaces.Api.Common;
+using MyPlaces.Api.Common.Entities;
+
+namespace MyPlaces.Api.Features.Trips;
+
+internal static class TripShareToken
+{
+    private const int MaxAttempts = 8;
+
+    /// <summary>URL-safe token (~43 chars from 32 random bytes).</summary>
+    public static string Generate()
+    {
+        Span<byte> bytes = stackalloc byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    public static async Task<string> GenerateUniqueAsync(AppDbContext db, CancellationToken ct)
+    {
+        for (var attempt = 0; attempt < MaxAttempts; attempt++)
+        {
+            var token = Generate();
+            var exists = await db.Trips.AnyAsync(t => t.ShareToken == token, ct);
+            if (!exists)
+                return token;
+        }
+
+        throw new InvalidOperationException("Could not generate a unique share token.");
+    }
+}

--- a/src/MyPlaces.Api/Features/Trips/UpdateTrip.cs
+++ b/src/MyPlaces.Api/Features/Trips/UpdateTrip.cs
@@ -1,0 +1,59 @@
+using Microsoft.EntityFrameworkCore;
+using MyPlaces.Api.Common;
+using MyPlaces.Api.Common.Entities;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Trips;
+using E = MyPlaces.Api.Common.Entities;
+
+namespace MyPlaces.Api.Features.Trips;
+
+public static class UpdateTrip
+{
+    public static async Task<IResult> Handle(
+        Guid id,
+        UpdateTripRequest req,
+        AppDbContext db,
+        ICurrentUser currentUser,
+        CancellationToken ct)
+    {
+        var trip = await db.Trips
+            .Include(t => t.TripPlaces)
+            .ThenInclude(tp => tp.Place)
+            .ThenInclude(p => p.Photos)
+            .FirstOrDefaultAsync(t => t.Id == id && t.UserId == currentUser.Id, ct);
+
+        if (trip is null)
+            return Results.NotFound();
+
+        trip.Name = req.Name;
+        trip.City = req.City;
+        trip.Country = req.Country;
+        trip.StartDate = req.StartDate;
+        trip.EndDate = req.EndDate;
+
+        var newVisibility = TripMappings.ToEntity(req.Visibility);
+        await ApplyVisibilityAsync(trip, newVisibility, db, ct);
+
+        await db.SaveChangesAsync(ct);
+
+        return Results.Ok(Result<TripDetailResponse>.Success(TripMappings.ToDetail(trip)));
+    }
+
+    internal static async Task ApplyVisibilityAsync(
+        Trip trip,
+        E.TripVisibility newVisibility,
+        AppDbContext db,
+        CancellationToken ct)
+    {
+        if (newVisibility == E.TripVisibility.Private)
+        {
+            trip.Visibility = E.TripVisibility.Private;
+            trip.ShareToken = null;
+            return;
+        }
+
+        trip.Visibility = E.TripVisibility.PublicLink;
+        if (string.IsNullOrEmpty(trip.ShareToken))
+            trip.ShareToken = await TripShareToken.GenerateUniqueAsync(db, ct);
+    }
+}

--- a/src/MyPlaces.Api/Program.cs
+++ b/src/MyPlaces.Api/Program.cs
@@ -39,9 +39,14 @@ builder.Services.AddScoped<ICurrentUser, CurrentUser>();
 builder.Services.AddScoped<JwtTokenService>();
 
 // CORS (Blazor WASM)
+var allowedOrigins = builder.Configuration["AllowedOrigins"]?.Split(
+    [';', ','],
+    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+    ?? ["http://localhost:5178", "https://localhost:7105"];
+
 builder.Services.AddCors(options =>
     options.AddDefaultPolicy(policy =>
-        policy.WithOrigins(builder.Configuration["AllowedOrigins"] ?? "http://localhost:5001")
+        policy.WithOrigins(allowedOrigins)
               .AllowAnyHeader()
               .AllowAnyMethod()
               .AllowCredentials()));

--- a/src/MyPlaces.Client/Layout/NavMenu.razor
+++ b/src/MyPlaces.Client/Layout/NavMenu.razor
@@ -1,6 +1,9 @@
-﻿<div class="top-row ps-3 navbar navbar-dark">
+﻿@inject AuthState Auth
+@inject NavigationManager Nav
+
+<div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
-        <a class="navbar-brand" href="">MyPlaces.Client</a>
+        <a class="navbar-brand" href="">My Places</a>
         <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
             <span class="navbar-toggler-icon"></span>
         </button>
@@ -15,14 +18,18 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
-            <NavLink class="nav-link" href="counter">
-                <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Counter
+            <NavLink class="nav-link" href="trips">
+                <span class="bi bi-map" aria-hidden="true"></span> Trips
             </NavLink>
         </div>
         <div class="nav-item px-3">
-            <NavLink class="nav-link" href="weather">
-                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
-            </NavLink>
+            <NavLink class="nav-link" href="login">Login</NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="register">Register</NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <button type="button" class="nav-link btn btn-link text-start p-0 border-0" @onclick="LogoutAsync">Logout</button>
         </div>
     </nav>
 </div>
@@ -35,5 +42,12 @@
     private void ToggleNavMenu()
     {
         collapseNavMenu = !collapseNavMenu;
+    }
+
+    private async Task LogoutAsync()
+    {
+        await Auth.SetTokenAsync(null);
+        Auth.ForgetCachedToken();
+        Nav.NavigateTo("/", forceLoad: true);
     }
 }

--- a/src/MyPlaces.Client/MyPlaces.Client.csproj
+++ b/src/MyPlaces.Client/MyPlaces.Client.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MyPlaces.Client/Pages/Login.razor
+++ b/src/MyPlaces.Client/Pages/Login.razor
@@ -1,0 +1,54 @@
+@page "/login"
+@using MyPlaces.Client.Serialization
+@inject IHttpClientFactory HttpFactory
+@inject AuthState Auth
+@inject NavigationManager Nav
+
+<PageTitle>Login</PageTitle>
+
+<h1>Login</h1>
+
+<EditForm Model="_model" OnValidSubmit="SubmitAsync">
+    <p>
+        <label>Email</label>
+        <InputText @bind-Value="_model.Email" class="form-control" />
+    </p>
+    <p>
+        <label>Password</label>
+        <InputText type="password" @bind-Value="_model.Password" class="form-control" />
+    </p>
+    <button type="submit" class="btn btn-primary">Sign in</button>
+</EditForm>
+@if (!string.IsNullOrEmpty(_error))
+{
+    <p class="text-danger mt-2">@_error</p>
+}
+
+@code {
+    private readonly LoginForm _model = new();
+    private string? _error;
+
+    private async Task SubmitAsync()
+    {
+        _error = null;
+        var client = HttpFactory.CreateClient("ApiAnonymous");
+        var response = await client.PostAsJsonAsync("api/v1/auth/login",
+            new LoginRequest(_model.Email, _model.Password));
+
+        var body = await response.Content.ReadFromJsonAsync<Result<AuthResponse>>(ClientJson.Options);
+        if (!response.IsSuccessStatusCode || body is null || !body.IsSuccess || body.Value is null)
+        {
+            _error = body?.Error ?? "Login failed.";
+            return;
+        }
+
+        await Auth.SetTokenAsync(body.Value.Token);
+        Nav.NavigateTo("/trips");
+    }
+
+    private sealed class LoginForm
+    {
+        public string Email { get; set; } = "";
+        public string Password { get; set; } = "";
+    }
+}

--- a/src/MyPlaces.Client/Pages/Register.razor
+++ b/src/MyPlaces.Client/Pages/Register.razor
@@ -1,0 +1,64 @@
+@page "/register"
+@using MyPlaces.Client.Serialization
+@inject IHttpClientFactory HttpFactory
+@inject AuthState Auth
+@inject NavigationManager Nav
+
+<PageTitle>Register</PageTitle>
+
+<h1>Register</h1>
+
+<EditForm Model="_model" OnValidSubmit="SubmitAsync">
+    <p>
+        <label>Email</label>
+        <InputText @bind-Value="_model.Email" class="form-control" />
+    </p>
+    <p>
+        <label>Username</label>
+        <InputText @bind-Value="_model.Username" class="form-control" />
+    </p>
+    <p>
+        <label>Display name</label>
+        <InputText @bind-Value="_model.DisplayName" class="form-control" />
+    </p>
+    <p>
+        <label>Password</label>
+        <InputText type="password" @bind-Value="_model.Password" class="form-control" />
+    </p>
+    <button type="submit" class="btn btn-primary">Create account</button>
+</EditForm>
+@if (!string.IsNullOrEmpty(_error))
+{
+    <p class="text-danger mt-2">@_error</p>
+}
+
+@code {
+    private readonly RegisterForm _model = new();
+    private string? _error;
+
+    private async Task SubmitAsync()
+    {
+        _error = null;
+        var client = HttpFactory.CreateClient("ApiAnonymous");
+        var response = await client.PostAsJsonAsync("api/v1/auth/register",
+            new RegisterRequest(_model.Email, _model.Username, _model.Password, _model.DisplayName));
+
+        var body = await response.Content.ReadFromJsonAsync<Result<AuthResponse>>(ClientJson.Options);
+        if (!response.IsSuccessStatusCode || body is null || !body.IsSuccess || body.Value is null)
+        {
+            _error = body?.Error ?? "Registration failed.";
+            return;
+        }
+
+        await Auth.SetTokenAsync(body.Value.Token);
+        Nav.NavigateTo("/trips");
+    }
+
+    private sealed class RegisterForm
+    {
+        public string Email { get; set; } = "";
+        public string Username { get; set; } = "";
+        public string DisplayName { get; set; } = "";
+        public string Password { get; set; } = "";
+    }
+}

--- a/src/MyPlaces.Client/Pages/Trips/SharedTripView.razor
+++ b/src/MyPlaces.Client/Pages/Trips/SharedTripView.razor
@@ -1,0 +1,69 @@
+@page "/shared/{Token}"
+@using MyPlaces.Client.Serialization
+@inject IHttpClientFactory HttpFactory
+
+<PageTitle>Shared trip</PageTitle>
+
+@if (_loading)
+{
+    <p>Loading…</p>
+}
+else if (!string.IsNullOrEmpty(_error))
+{
+    <p class="text-danger">@_error</p>
+}
+else if (_trip is not null)
+{
+    <h1>@_trip.Name</h1>
+    <p>@_trip.City @(_trip.Country is not null ? $", {_trip.Country}" : "")</p>
+
+    <h2>Places</h2>
+    @if (_trip.Places.Count == 0)
+    {
+        <p>No places.</p>
+    }
+    else
+    {
+        <ul class="list-group">
+            @foreach (var tp in _trip.Places)
+            {
+                <li class="list-group-item">@tp.Place.Name — @tp.Place.City</li>
+            }
+        </ul>
+    }
+}
+
+@code {
+    [Parameter] public string Token { get; set; } = "";
+
+    private bool _loading = true;
+    private string? _error;
+    private TripDetailResponse? _trip;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        _loading = true;
+        _error = null;
+        try
+        {
+            var client = HttpFactory.CreateClient("ApiAnonymous");
+            var r = await client.GetFromJsonAsync<Result<TripDetailResponse>>($"api/v1/trips/shared/{Uri.EscapeDataString(Token)}",
+                ClientJson.Options);
+            if (r is not { IsSuccess: true, Value: not null })
+            {
+                _error = "This trip is not available (invalid or private link).";
+                return;
+            }
+
+            _trip = r.Value;
+        }
+        catch
+        {
+            _error = "This trip is not available (invalid or private link).";
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+}

--- a/src/MyPlaces.Client/Pages/Trips/TripDetail.razor
+++ b/src/MyPlaces.Client/Pages/Trips/TripDetail.razor
@@ -1,0 +1,154 @@
+@page "/trips/{TripId:guid}"
+@using MyPlaces.Client.Serialization
+@inject IHttpClientFactory HttpFactory
+@inject NavigationManager Nav
+
+<PageTitle>Trip</PageTitle>
+
+@if (_loading)
+{
+    <p>Loading…</p>
+}
+else if (!string.IsNullOrEmpty(_error))
+{
+    <p class="text-danger">@_error</p>
+}
+else if (_trip is not null)
+{
+    <h1>@_trip.Name</h1>
+    <p>@_trip.City @(_trip.Country is not null ? $", {_trip.Country}" : "")</p>
+    <p>
+        <a class="btn btn-outline-secondary" href="trips/@TripId/edit">Edit</a>
+        <button type="button" class="btn btn-outline-primary" @onclick="ToggleShareAsync">Share / unshare</button>
+    </p>
+    @if (_shareInfo is not null)
+    {
+        <div class="alert alert-info">
+            <div><strong>Visibility:</strong> @_shareInfo.Visibility</div>
+            @if (!string.IsNullOrEmpty(_shareInfo.SharePath))
+            {
+                <div><strong>Path:</strong> @_shareInfo.SharePath</div>
+                <div><strong>Open:</strong> <a href="@($"{Nav.BaseUri.TrimEnd('/')}{_shareInfo.SharePath}")">@($"{Nav.BaseUri.TrimEnd('/')}{_shareInfo.SharePath}")</a></div>
+            }
+        </div>
+    }
+
+    <h2>Places</h2>
+    @if (_myPlaces is not null && _myPlaces.Count > 0)
+    {
+        <div class="input-group mb-3" style="max-width: 28rem;">
+            <select class="form-select" @bind="_selectedPlaceId">
+                <option value="">— add a place —</option>
+                @foreach (var p in _myPlaces)
+                {
+                    <option value="@p.Id">@p.Name (@p.City)</option>
+                }
+            </select>
+            <button class="btn btn-outline-primary" type="button" @onclick="AddPlaceAsync" disabled="@string.IsNullOrEmpty(_selectedPlaceId)">Add</button>
+        </div>
+    }
+
+    @if (_trip.Places.Count == 0)
+    {
+        <p>No places in this trip.</p>
+    }
+    else
+    {
+        <ul class="list-group">
+            @foreach (var tp in _trip.Places)
+            {
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span>@tp.Place.Name — @tp.Place.City</span>
+                    <button type="button" class="btn btn-sm btn-outline-danger" @onclick="() => RemovePlaceAsync(tp.Place.Id)">Remove</button>
+                </li>
+            }
+        </ul>
+    }
+}
+
+@code {
+    [Parameter] public Guid TripId { get; set; }
+
+    private bool _loading = true;
+    private string? _error;
+    private TripDetailResponse? _trip;
+    private List<PlaceSummaryResponse>? _myPlaces;
+    private string _selectedPlaceId = "";
+    private ShareTripResponse? _shareInfo;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        _error = null;
+        try
+        {
+            var client = HttpFactory.CreateClient("Api");
+            var tripResult = await client.GetFromJsonAsync<Result<TripDetailResponse>>($"api/v1/trips/{TripId}", ClientJson.Options);
+            if (tripResult is not { IsSuccess: true, Value: not null })
+            {
+                _error = tripResult?.Error ?? "Trip not found.";
+                return;
+            }
+
+            _trip = tripResult.Value;
+
+            var placesResult = await client.GetFromJsonAsync<Result<List<PlaceSummaryResponse>>>("api/v1/places", ClientJson.Options);
+            _myPlaces = placesResult is { IsSuccess: true, Value: not null } ? placesResult.Value : [];
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+            if (_error.Contains("401"))
+                Nav.NavigateTo("/login");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task AddPlaceAsync()
+    {
+        if (_trip is null || !Guid.TryParse(_selectedPlaceId, out var placeId))
+            return;
+        var client = HttpFactory.CreateClient("Api");
+        var resp = await client.PostAsync($"api/v1/trips/{TripId}/places/{placeId}", null);
+        if (!resp.IsSuccessStatusCode)
+        {
+            _error = $"Add failed ({(int)resp.StatusCode}).";
+            return;
+        }
+
+        _selectedPlaceId = "";
+        await LoadAsync();
+    }
+
+    private async Task RemovePlaceAsync(Guid placeId)
+    {
+        var client = HttpFactory.CreateClient("Api");
+        var resp = await client.DeleteAsync($"api/v1/trips/{TripId}/places/{placeId}");
+        if (!resp.IsSuccessStatusCode)
+        {
+            _error = $"Remove failed ({(int)resp.StatusCode}).";
+            return;
+        }
+
+        await LoadAsync();
+    }
+
+    private async Task ToggleShareAsync()
+    {
+        var client = HttpFactory.CreateClient("Api");
+        var resp = await client.PostAsync($"api/v1/trips/{TripId}/share", null);
+        var body = await resp.Content.ReadFromJsonAsync<Result<ShareTripResponse>>(ClientJson.Options);
+        if (resp.IsSuccessStatusCode && body is { IsSuccess: true, Value: not null })
+            _shareInfo = body.Value;
+        else
+            _error = body?.Error ?? "Share failed.";
+    }
+}

--- a/src/MyPlaces.Client/Pages/Trips/TripEditor.razor
+++ b/src/MyPlaces.Client/Pages/Trips/TripEditor.razor
@@ -1,0 +1,155 @@
+@page "/trips/new"
+@page "/trips/{TripId:guid}/edit"
+@using MyPlaces.Client.Serialization
+@inject IHttpClientFactory HttpFactory
+@inject NavigationManager Nav
+
+<PageTitle>@(_isNew ? "New trip" : "Edit trip")</PageTitle>
+
+<h1>@(_isNew ? "New trip" : "Edit trip")</h1>
+
+@if (_loading)
+{
+    <p>Loading…</p>
+}
+else if (!string.IsNullOrEmpty(_error))
+{
+    <p class="text-danger">@_error</p>
+}
+else
+{
+    <EditForm Model="_model" OnValidSubmit="SaveAsync">
+        <p>
+            <label>Name</label>
+            <InputText @bind-Value="_model.Name" class="form-control" />
+        </p>
+        <p>
+            <label>City</label>
+            <InputText @bind-Value="_model.City" class="form-control" />
+        </p>
+        <p>
+            <label>Country</label>
+            <InputText @bind-Value="_model.Country" class="form-control" />
+        </p>
+        <p>
+            <label>Start</label>
+            <InputDate @bind-Value="_model.StartDate" class="form-control" Type="InputDateType.Date" />
+        </p>
+        <p>
+            <label>End</label>
+            <InputDate @bind-Value="_model.EndDate" class="form-control" Type="InputDateType.Date" />
+        </p>
+        <p>
+            <label>Visibility</label>
+            <InputSelect @bind-Value="_model.Visibility" class="form-control">
+                <option value="@TripVisibility.Private">Private</option>
+                <option value="@TripVisibility.PublicLink">Public link</option>
+            </InputSelect>
+        </p>
+        <button type="submit" class="btn btn-primary">Save</button>
+        <a class="btn btn-link" href="trips">Cancel</a>
+    </EditForm>
+}
+
+@code {
+    [Parameter] public Guid TripId { get; set; }
+
+    private bool _isNew;
+    private bool _loading = true;
+    private string? _error;
+    private TripForm _model = new();
+
+    protected override async Task OnParametersSetAsync()
+    {
+        _isNew = Nav.Uri.Contains("/trips/new", StringComparison.OrdinalIgnoreCase);
+        _loading = true;
+        _error = null;
+
+        try
+        {
+            if (_isNew)
+            {
+                _model = new TripForm();
+            }
+            else
+            {
+                var client = HttpFactory.CreateClient("Api");
+                var r = await client.GetFromJsonAsync<Result<TripDetailResponse>>($"api/v1/trips/{TripId}", ClientJson.Options);
+                if (r is not { IsSuccess: true, Value: not null })
+                {
+                    _error = r?.Error ?? "Trip not found.";
+                    return;
+                }
+
+                var t = r.Value;
+                _model = new TripForm
+                {
+                    Name = t.Name,
+                    City = t.City,
+                    Country = t.Country ?? "",
+                    StartDate = t.StartDate,
+                    EndDate = t.EndDate,
+                    Visibility = t.Visibility
+                };
+            }
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+            if (_error.Contains("401"))
+                Nav.NavigateTo("/login");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task SaveAsync()
+    {
+        _error = null;
+        var client = HttpFactory.CreateClient("Api");
+        if (_isNew)
+        {
+            var req = new CreateTripRequest(
+                _model.Name, _model.City,
+                string.IsNullOrWhiteSpace(_model.Country) ? null : _model.Country,
+                _model.StartDate, _model.EndDate, _model.Visibility);
+            var resp = await client.PostAsJsonAsync("api/v1/trips", req);
+            var body = await resp.Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ClientJson.Options);
+            if (!resp.IsSuccessStatusCode || body is not { IsSuccess: true, Value: not null })
+            {
+                _error = body?.Error ?? "Could not create trip.";
+                return;
+            }
+
+            Nav.NavigateTo($"/trips/{body.Value.Id}");
+        }
+        else
+        {
+            var req = new UpdateTripRequest(
+                _model.Name, _model.City,
+                string.IsNullOrWhiteSpace(_model.Country) ? null : _model.Country,
+                _model.StartDate, _model.EndDate, _model.Visibility);
+            var resp = await client.PutAsJsonAsync($"api/v1/trips/{TripId}", req);
+            var body = await resp.Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ClientJson.Options);
+            if (!resp.IsSuccessStatusCode || body is not { IsSuccess: true, Value: not null })
+            {
+                _error = body?.Error ?? "Could not update trip.";
+                return;
+            }
+
+            Nav.NavigateTo($"/trips/{TripId}");
+        }
+    }
+
+    private sealed class TripForm
+    {
+        public string Name { get; set; } = "";
+        public string City { get; set; } = "";
+        public string Country { get; set; } = "";
+        public DateTime? StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+        public TripVisibility Visibility { get; set; } = TripVisibility.Private;
+    }
+}

--- a/src/MyPlaces.Client/Pages/Trips/TripList.razor
+++ b/src/MyPlaces.Client/Pages/Trips/TripList.razor
@@ -1,0 +1,62 @@
+@page "/trips"
+@using MyPlaces.Client.Serialization
+@inject IHttpClientFactory HttpFactory
+@inject NavigationManager Nav
+
+<PageTitle>Trips</PageTitle>
+
+<h1>My trips</h1>
+<p><a class="btn btn-primary" href="trips/new">New trip</a></p>
+
+@if (_loading)
+{
+    <p>Loading…</p>
+}
+else if (!string.IsNullOrEmpty(_error))
+{
+    <p class="text-danger">@_error</p>
+}
+else if (_trips is null || _trips.Count == 0)
+{
+    <p>No trips yet.</p>
+}
+else
+{
+    <ul class="list-group">
+        @foreach (var t in _trips)
+        {
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+                <a href="trips/@t.Id">@t.Name</a>
+                <span class="badge bg-secondary">@t.PlaceCount places</span>
+            </li>
+        }
+    </ul>
+}
+
+@code {
+    private bool _loading = true;
+    private string? _error;
+    private List<TripSummaryResponse>? _trips;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            var client = HttpFactory.CreateClient("Api");
+            _trips = await client.GetFromJsonAsync<Result<List<TripSummaryResponse>>>("api/v1/trips", ClientJson.Options)
+                is { } r && r.IsSuccess && r.Value is not null
+                ? r.Value
+                : [];
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+            if (_error.Contains("401"))
+                Nav.NavigateTo("/login");
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+}

--- a/src/MyPlaces.Client/Program.cs
+++ b/src/MyPlaces.Client/Program.cs
@@ -1,10 +1,22 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MyPlaces.Client;
+using MyPlaces.Client.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
+
+builder.Services.AddScoped<AuthState>();
+builder.Services.AddTransient<AuthTokenHandler>();
+
+var apiBase = builder.Configuration["ApiBaseUrl"] ?? "http://localhost:5160/";
+if (!apiBase.EndsWith('/'))
+    apiBase += "/";
+
+builder.Services.AddHttpClient("Api", client => client.BaseAddress = new Uri(apiBase))
+    .AddHttpMessageHandler<AuthTokenHandler>();
+builder.Services.AddHttpClient("ApiAnonymous", client => client.BaseAddress = new Uri(apiBase));
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 

--- a/src/MyPlaces.Client/Serialization/ClientJson.cs
+++ b/src/MyPlaces.Client/Serialization/ClientJson.cs
@@ -1,0 +1,13 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MyPlaces.Client.Serialization;
+
+public static class ClientJson
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+}

--- a/src/MyPlaces.Client/Services/AuthState.cs
+++ b/src/MyPlaces.Client/Services/AuthState.cs
@@ -1,0 +1,27 @@
+using Microsoft.JSInterop;
+
+namespace MyPlaces.Client.Services;
+
+public class AuthState(IJSRuntime js)
+{
+    private const string StorageKey = "myplaces.jwt";
+    private string? _memory;
+
+    public async ValueTask<string?> GetTokenAsync()
+    {
+        if (_memory is not null)
+            return _memory;
+        return await js.InvokeAsync<string?>("localStorage.getItem", StorageKey);
+    }
+
+    public async ValueTask SetTokenAsync(string? token)
+    {
+        _memory = token;
+        if (string.IsNullOrEmpty(token))
+            await js.InvokeVoidAsync("localStorage.removeItem", StorageKey);
+        else
+            await js.InvokeVoidAsync("localStorage.setItem", StorageKey, token);
+    }
+
+    public void ForgetCachedToken() => _memory = null;
+}

--- a/src/MyPlaces.Client/Services/AuthTokenHandler.cs
+++ b/src/MyPlaces.Client/Services/AuthTokenHandler.cs
@@ -1,0 +1,16 @@
+using System.Net.Http.Headers;
+
+namespace MyPlaces.Client.Services;
+
+public class AuthTokenHandler(AuthState auth) : DelegatingHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var token = await auth.GetTokenAsync();
+        if (!string.IsNullOrEmpty(token))
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/MyPlaces.Client/_Imports.razor
+++ b/src/MyPlaces.Client/_Imports.razor
@@ -1,5 +1,10 @@
 ﻿@using System.Net.Http
+@using System.Net.Http.Headers
 @using System.Net.Http.Json
+@using MyPlaces.Shared.Auth
+@using MyPlaces.Shared.Common
+@using MyPlaces.Shared.Places
+@using MyPlaces.Shared.Trips
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
@@ -8,3 +13,4 @@
 @using Microsoft.JSInterop
 @using MyPlaces.Client
 @using MyPlaces.Client.Layout
+@using MyPlaces.Client.Services

--- a/src/MyPlaces.Client/wwwroot/appsettings.Development.json
+++ b/src/MyPlaces.Client/wwwroot/appsettings.Development.json
@@ -1,0 +1,3 @@
+{
+  "ApiBaseUrl": "http://localhost:5160/"
+}

--- a/src/MyPlaces.Client/wwwroot/appsettings.json
+++ b/src/MyPlaces.Client/wwwroot/appsettings.json
@@ -1,0 +1,3 @@
+{
+  "ApiBaseUrl": "http://localhost:5160/"
+}

--- a/src/MyPlaces.Shared/Trips/TripRequest.cs
+++ b/src/MyPlaces.Shared/Trips/TripRequest.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MyPlaces.Shared.Trips;
+
+public record CreateTripRequest(
+    [Required] string Name,
+    [Required] string City,
+    string? Country,
+    DateTime? StartDate,
+    DateTime? EndDate,
+    TripVisibility Visibility = TripVisibility.Private
+);
+
+public record UpdateTripRequest(
+    [Required] string Name,
+    [Required] string City,
+    string? Country,
+    DateTime? StartDate,
+    DateTime? EndDate,
+    TripVisibility Visibility
+);

--- a/src/MyPlaces.Shared/Trips/TripResponse.cs
+++ b/src/MyPlaces.Shared/Trips/TripResponse.cs
@@ -1,0 +1,34 @@
+using MyPlaces.Shared.Places;
+
+namespace MyPlaces.Shared.Trips;
+
+public record TripSummaryResponse(
+    Guid Id,
+    string Name,
+    string City,
+    DateTime? StartDate,
+    DateTime? EndDate,
+    TripVisibility Visibility,
+    int PlaceCount,
+    DateTime CreatedAt
+);
+
+public record TripPlaceResponse(DateTime AddedAt, PlaceResponse Place);
+
+public record TripDetailResponse(
+    Guid Id,
+    string Name,
+    string City,
+    string? Country,
+    DateTime? StartDate,
+    DateTime? EndDate,
+    TripVisibility Visibility,
+    DateTime CreatedAt,
+    IReadOnlyList<TripPlaceResponse> Places
+);
+
+public record ShareTripResponse(
+    TripVisibility Visibility,
+    string? ShareToken,
+    string? SharePath
+);

--- a/src/MyPlaces.Shared/Trips/TripVisibility.cs
+++ b/src/MyPlaces.Shared/Trips/TripVisibility.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace MyPlaces.Shared.Trips;
+
+[JsonConverter(typeof(JsonStringEnumConverter<TripVisibility>))]
+public enum TripVisibility
+{
+    Private,
+    PublicLink
+}

--- a/tests/MyPlaces.Api.Tests/AuthenticatedTestBase.cs
+++ b/tests/MyPlaces.Api.Tests/AuthenticatedTestBase.cs
@@ -1,5 +1,7 @@
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using MyPlaces.Shared.Auth;
 using MyPlaces.Shared.Common;
 
@@ -8,9 +10,17 @@ namespace MyPlaces.Api.Tests;
 public abstract class AuthenticatedTestBase : IClassFixture<TestWebAppFactory>
 {
     protected readonly HttpClient Client;
+    protected readonly TestWebAppFactory Factory;
+
+    protected static readonly JsonSerializerOptions ApiJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
 
     protected AuthenticatedTestBase(TestWebAppFactory factory)
     {
+        Factory = factory;
         Client = factory.CreateClient();
     }
 

--- a/tests/MyPlaces.Api.Tests/Features/Trips/AddRemovePlaceToTripTests.cs
+++ b/tests/MyPlaces.Api.Tests/Features/Trips/AddRemovePlaceToTripTests.cs
@@ -1,0 +1,77 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Places;
+using MyPlaces.Shared.Trips;
+
+namespace MyPlaces.Api.Tests.Features.Trips;
+
+public class AddRemovePlaceToTripTests(TestWebAppFactory factory) : AuthenticatedTestBase(factory)
+{
+    [Fact]
+    public async Task AddPlaceTwice_SecondReturns409()
+    {
+        await RegisterAndLoginAsync(email: "trip-ap1@test.com", username: "trip-ap1");
+
+        var tripId = (await (await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("T", "C", null, null, null)))
+            .Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson))!.Value!.Id;
+        var placeId = (await (await Client.PostAsJsonAsync("/api/v1/places", new CreatePlaceRequest("P", "A", "C", null, null, null, null)))
+            .Content.ReadFromJsonAsync<Result<PlaceResponse>>())!.Value!.Id;
+
+        var first = await Client.PostAsync($"/api/v1/trips/{tripId}/places/{placeId}", null);
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var second = await Client.PostAsync($"/api/v1/trips/{tripId}/places/{placeId}", null);
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task AddPlace_OtherUsersPlace_Returns404()
+    {
+        await RegisterAndLoginAsync(email: "trip-ap2a@test.com", username: "trip-ap2a");
+        var placeId = (await (await Client.PostAsJsonAsync("/api/v1/places", new CreatePlaceRequest("P", "A", "C", null, null, null, null)))
+            .Content.ReadFromJsonAsync<Result<PlaceResponse>>())!.Value!.Id;
+
+        Client.DefaultRequestHeaders.Clear();
+        await RegisterAndLoginAsync(email: "trip-ap2b@test.com", username: "trip-ap2b");
+        var tripId = (await (await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("T", "C", null, null, null)))
+            .Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson))!.Value!.Id;
+
+        var response = await Client.PostAsync($"/api/v1/trips/{tripId}/places/{placeId}", null);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task RemovePlace_RemovesMembershipOnly()
+    {
+        await RegisterAndLoginAsync(email: "trip-ap3@test.com", username: "trip-ap3");
+
+        var tripId = (await (await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("T", "C", null, null, null)))
+            .Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson))!.Value!.Id;
+        var placeId = (await (await Client.PostAsJsonAsync("/api/v1/places", new CreatePlaceRequest("P", "A", "C", null, null, null, null)))
+            .Content.ReadFromJsonAsync<Result<PlaceResponse>>())!.Value!.Id;
+
+        await Client.PostAsync($"/api/v1/trips/{tripId}/places/{placeId}", null);
+
+        var del = await Client.DeleteAsync($"/api/v1/trips/{tripId}/places/{placeId}");
+        del.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var getPlace = await Client.GetAsync($"/api/v1/places/{placeId}");
+        getPlace.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task RemovePlace_NotMember_Returns404()
+    {
+        await RegisterAndLoginAsync(email: "trip-ap4@test.com", username: "trip-ap4");
+
+        var tripId = (await (await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("T", "C", null, null, null)))
+            .Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson))!.Value!.Id;
+        var placeId = (await (await Client.PostAsJsonAsync("/api/v1/places", new CreatePlaceRequest("P", "A", "C", null, null, null, null)))
+            .Content.ReadFromJsonAsync<Result<PlaceResponse>>())!.Value!.Id;
+
+        var del = await Client.DeleteAsync($"/api/v1/trips/{tripId}/places/{placeId}");
+        del.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/MyPlaces.Api.Tests/Features/Trips/CreateTripTests.cs
+++ b/tests/MyPlaces.Api.Tests/Features/Trips/CreateTripTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MyPlaces.Api.Common;
+using Entities = MyPlaces.Api.Common.Entities;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Trips;
+
+namespace MyPlaces.Api.Tests.Features.Trips;
+
+public class CreateTripTests(TestWebAppFactory factory) : AuthenticatedTestBase(factory)
+{
+    [Fact]
+    public async Task CreateTrip_Authenticated_ReturnsTrip()
+    {
+        await RegisterAndLoginAsync(email: "trip-create1@test.com", username: "trip-create1");
+
+        var req = new CreateTripRequest(
+            Name: "Summer",
+            City: "Hanoi",
+            Country: "VN",
+            StartDate: new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate: new DateTime(2026, 6, 10, 0, 0, 0, DateTimeKind.Utc),
+            Visibility: TripVisibility.Private);
+
+        var response = await Client.PostAsJsonAsync("/api/v1/trips", req);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.Name.Should().Be("Summer");
+        result.Value.City.Should().Be("Hanoi");
+        result.Value.Visibility.Should().Be(TripVisibility.Private);
+        result.Value.Places.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateTrip_PublicLink_GeneratesShareToken()
+    {
+        await RegisterAndLoginAsync(email: "trip-create2@test.com", username: "trip-create2");
+
+        var req = new CreateTripRequest(
+            "Pub", "HCMC", null, null, null, TripVisibility.PublicLink);
+
+        var response = await Client.PostAsJsonAsync("/api/v1/trips", req);
+
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson);
+        result!.Value!.Visibility.Should().Be(TripVisibility.PublicLink);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var trip = await db.Trips.SingleAsync(t => t.Name == "Pub");
+        trip.ShareToken.Should().NotBeNullOrEmpty();
+        trip.Visibility.Should().Be(Entities.TripVisibility.PublicLink);
+    }
+
+    [Fact]
+    public async Task CreateTrip_Unauthenticated_Returns401()
+    {
+        Client.DefaultRequestHeaders.Clear();
+        var req = new CreateTripRequest("T", "C", null, null, null);
+
+        var response = await Client.PostAsJsonAsync("/api/v1/trips", req);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/tests/MyPlaces.Api.Tests/Features/Trips/DeleteTripTests.cs
+++ b/tests/MyPlaces.Api.Tests/Features/Trips/DeleteTripTests.cs
@@ -1,0 +1,39 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Trips;
+
+namespace MyPlaces.Api.Tests.Features.Trips;
+
+public class DeleteTripTests(TestWebAppFactory factory) : AuthenticatedTestBase(factory)
+{
+    [Fact]
+    public async Task DeleteTrip_Owner_Returns204_AndSubsequentGet404()
+    {
+        await RegisterAndLoginAsync(email: "trip-del1@test.com", username: "trip-del1");
+
+        var tripId = (await (await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("N", "C", null, null, null)))
+            .Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson))!.Value!.Id;
+
+        var del = await Client.DeleteAsync($"/api/v1/trips/{tripId}");
+        del.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var get = await Client.GetAsync($"/api/v1/trips/{tripId}");
+        get.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteTrip_OtherUser_Returns404()
+    {
+        await RegisterAndLoginAsync(email: "trip-del2a@test.com", username: "trip-del2a");
+        var tripId = (await (await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("N", "C", null, null, null)))
+            .Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson))!.Value!.Id;
+
+        Client.DefaultRequestHeaders.Clear();
+        await RegisterAndLoginAsync(email: "trip-del2b@test.com", username: "trip-del2b");
+
+        var del = await Client.DeleteAsync($"/api/v1/trips/{tripId}");
+        del.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/MyPlaces.Api.Tests/Features/Trips/GetSharedTripTests.cs
+++ b/tests/MyPlaces.Api.Tests/Features/Trips/GetSharedTripTests.cs
@@ -1,0 +1,55 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Trips;
+
+namespace MyPlaces.Api.Tests.Features.Trips;
+
+public class GetSharedTripTests(TestWebAppFactory factory) : AuthenticatedTestBase(factory)
+{
+    [Fact]
+    public async Task GetSharedTrip_PublicLink_ReturnsTripWithoutAuth()
+    {
+        await RegisterAndLoginAsync(email: "trip-gsh1@test.com", username: "trip-gsh1");
+
+        var tripId = (await (await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("T", "C", null, null, null)))
+            .Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson))!.Value!.Id;
+
+        var share = await Client.PostAsync($"/api/v1/trips/{tripId}/share", null);
+        var token = (await share.Content.ReadFromJsonAsync<Result<ShareTripResponse>>(ApiJson))!.Value!.ShareToken!;
+
+        var anon = Factory.CreateClient();
+        var response = await anon.GetAsync($"/api/v1/trips/shared/{token}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson);
+        result!.Value!.Name.Should().Be("T");
+    }
+
+    [Fact]
+    public async Task GetSharedTrip_BadToken_Returns404()
+    {
+        var anon = Factory.CreateClient();
+        var response = await anon.GetAsync("/api/v1/trips/shared/invalid-token-xxxxxxxx");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetSharedTrip_WhenPrivate_Returns404()
+    {
+        await RegisterAndLoginAsync(email: "trip-gsh2@test.com", username: "trip-gsh2");
+
+        var tripId = (await (await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("T", "C", null, null, null)))
+            .Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson))!.Value!.Id;
+
+        var share = await Client.PostAsync($"/api/v1/trips/{tripId}/share", null);
+        var token = (await share.Content.ReadFromJsonAsync<Result<ShareTripResponse>>(ApiJson))!.Value!.ShareToken!;
+
+        await Client.PostAsync($"/api/v1/trips/{tripId}/share", null);
+
+        var anon = Factory.CreateClient();
+        var response = await anon.GetAsync($"/api/v1/trips/shared/{token}");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/MyPlaces.Api.Tests/Features/Trips/GetTripTests.cs
+++ b/tests/MyPlaces.Api.Tests/Features/Trips/GetTripTests.cs
@@ -1,0 +1,58 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Places;
+using MyPlaces.Shared.Trips;
+
+namespace MyPlaces.Api.Tests.Features.Trips;
+
+public class GetTripTests(TestWebAppFactory factory) : AuthenticatedTestBase(factory)
+{
+    [Fact]
+    public async Task GetTrip_Owner_ReturnsDetailWithPlacesOrdered()
+    {
+        await RegisterAndLoginAsync(email: "trip-get1@test.com", username: "trip-get1");
+
+        var tripId = (await (await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("T", "C", null, null, null)))
+            .Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson))!.Value!.Id;
+
+        var p1 = (await (await Client.PostAsJsonAsync("/api/v1/places", new CreatePlaceRequest("P1", "A", "C", null, null, null, null)))
+            .Content.ReadFromJsonAsync<Result<PlaceResponse>>())!.Value!.Id;
+        var p2 = (await (await Client.PostAsJsonAsync("/api/v1/places", new CreatePlaceRequest("P2", "A", "C", null, null, null, null)))
+            .Content.ReadFromJsonAsync<Result<PlaceResponse>>())!.Value!.Id;
+
+        await Client.PostAsync($"/api/v1/trips/{tripId}/places/{p1}", null);
+        await Task.Delay(5);
+        await Client.PostAsync($"/api/v1/trips/{tripId}/places/{p2}", null);
+
+        var response = await Client.GetAsync($"/api/v1/trips/{tripId}");
+        var result = await response.Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson);
+
+        result!.Value!.Places.Should().HaveCount(2);
+        result.Value.Places[0].Place.Name.Should().Be("P1");
+        result.Value.Places[1].Place.Name.Should().Be("P2");
+    }
+
+    [Fact]
+    public async Task GetTrip_UnknownId_Returns404()
+    {
+        await RegisterAndLoginAsync(email: "trip-get2@test.com", username: "trip-get2");
+        var response = await Client.GetAsync($"/api/v1/trips/{Guid.NewGuid()}");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetTrip_OtherUsersTrip_Returns404()
+    {
+        await RegisterAndLoginAsync(email: "trip-get3a@test.com", username: "trip-get3a");
+        var tripId = (await (await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("T", "C", null, null, null)))
+            .Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson))!.Value!.Id;
+
+        Client.DefaultRequestHeaders.Clear();
+        await RegisterAndLoginAsync(email: "trip-get3b@test.com", username: "trip-get3b");
+
+        var response = await Client.GetAsync($"/api/v1/trips/{tripId}");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/MyPlaces.Api.Tests/Features/Trips/GetTripsTests.cs
+++ b/tests/MyPlaces.Api.Tests/Features/Trips/GetTripsTests.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Places;
+using MyPlaces.Shared.Trips;
+
+namespace MyPlaces.Api.Tests.Features.Trips;
+
+public class GetTripsTests(TestWebAppFactory factory) : AuthenticatedTestBase(factory)
+{
+    [Fact]
+    public async Task GetTrips_ReturnsOnlyOwnTrips_OrderedByCreatedDesc()
+    {
+        await RegisterAndLoginAsync(email: "trip-list1@test.com", username: "trip-list1");
+
+        await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("A", "City", null, null, null));
+        await Task.Delay(5);
+        await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("B", "City", null, null, null));
+
+        var response = await Client.GetAsync("/api/v1/trips");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<List<TripSummaryResponse>>>(ApiJson);
+        result!.Value!.Should().HaveCount(2);
+        result.Value[0].Name.Should().Be("B");
+        result.Value[1].Name.Should().Be("A");
+    }
+
+    [Fact]
+    public async Task GetTrips_IncludesPlaceCount()
+    {
+        await RegisterAndLoginAsync(email: "trip-list2@test.com", username: "trip-list2");
+
+        var tripResp = await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("T", "C", null, null, null));
+        var tripId = (await tripResp.Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson))!.Value!.Id;
+
+        var placeResp = await Client.PostAsJsonAsync("/api/v1/places", new CreatePlaceRequest(
+            "P", "Addr", "C", null, null, null, null));
+        var placeId = (await placeResp.Content.ReadFromJsonAsync<Result<PlaceResponse>>())!.Value!.Id;
+
+        await Client.PostAsync($"/api/v1/trips/{tripId}/places/{placeId}", null);
+
+        var listResp = await Client.GetAsync("/api/v1/trips");
+        var list = await listResp.Content.ReadFromJsonAsync<Result<List<TripSummaryResponse>>>(ApiJson);
+        list!.Value!.Single().PlaceCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetTrips_Unauthenticated_Returns401()
+    {
+        Client.DefaultRequestHeaders.Clear();
+        var response = await Client.GetAsync("/api/v1/trips");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/tests/MyPlaces.Api.Tests/Features/Trips/ShareTripTests.cs
+++ b/tests/MyPlaces.Api.Tests/Features/Trips/ShareTripTests.cs
@@ -1,0 +1,58 @@
+using System.Net.Http.Json;
+using FluentAssertions;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Trips;
+
+namespace MyPlaces.Api.Tests.Features.Trips;
+
+public class ShareTripTests(TestWebAppFactory factory) : AuthenticatedTestBase(factory)
+{
+    [Fact]
+    public async Task ShareTrip_PrivateToPublic_YieldsToken_PublicToPrivate_Clears()
+    {
+        await RegisterAndLoginAsync(email: "trip-sh1@test.com", username: "trip-sh1");
+
+        var tripId = (await (await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("T", "C", null, null, null)))
+            .Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson))!.Value!.Id;
+
+        var pub = await Client.PostAsync($"/api/v1/trips/{tripId}/share", null);
+        pub.EnsureSuccessStatusCode();
+        var pubBody = await pub.Content.ReadFromJsonAsync<Result<ShareTripResponse>>(ApiJson);
+        pubBody!.Value!.Visibility.Should().Be(TripVisibility.PublicLink);
+        pubBody.Value.ShareToken.Should().NotBeNullOrEmpty();
+        pubBody.Value.SharePath.Should().StartWith("/shared/");
+
+        var priv = await Client.PostAsync($"/api/v1/trips/{tripId}/share", null);
+        priv.EnsureSuccessStatusCode();
+        var privBody = await priv.Content.ReadFromJsonAsync<Result<ShareTripResponse>>(ApiJson);
+        privBody!.Value!.Visibility.Should().Be(TripVisibility.Private);
+        privBody.Value.ShareToken.Should().BeNull();
+        privBody.Value.SharePath.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ShareTrip_SecondPublicToggle_GeneratesNewToken()
+    {
+        await RegisterAndLoginAsync(email: "trip-sh2@test.com", username: "trip-sh2");
+
+        var tripId = (await (await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("T", "C", null, null, null)))
+            .Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson))!.Value!.Id;
+
+        var first = await Client.PostAsync($"/api/v1/trips/{tripId}/share", null);
+        var token1 = (await first.Content.ReadFromJsonAsync<Result<ShareTripResponse>>(ApiJson))!.Value!.ShareToken;
+
+        await Client.PostAsync($"/api/v1/trips/{tripId}/share", null);
+        var third = await Client.PostAsync($"/api/v1/trips/{tripId}/share", null);
+        var token2 = (await third.Content.ReadFromJsonAsync<Result<ShareTripResponse>>(ApiJson))!.Value!.ShareToken;
+
+        token2.Should().NotBe(token1);
+    }
+
+    [Fact]
+    public async Task ShareTrip_NotFound_Returns404()
+    {
+        await RegisterAndLoginAsync(email: "trip-sh3@test.com", username: "trip-sh3");
+        var response = await Client.PostAsync($"/api/v1/trips/{Guid.NewGuid()}/share", null);
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+    }
+}

--- a/tests/MyPlaces.Api.Tests/Features/Trips/UpdateTripTests.cs
+++ b/tests/MyPlaces.Api.Tests/Features/Trips/UpdateTripTests.cs
@@ -1,0 +1,81 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MyPlaces.Api.Common;
+using Entities = MyPlaces.Api.Common.Entities;
+using MyPlaces.Shared.Common;
+using MyPlaces.Shared.Trips;
+
+namespace MyPlaces.Api.Tests.Features.Trips;
+
+public class UpdateTripTests(TestWebAppFactory factory) : AuthenticatedTestBase(factory)
+{
+    [Fact]
+    public async Task UpdateTrip_Owner_UpdatesFields()
+    {
+        await RegisterAndLoginAsync(email: "trip-up1@test.com", username: "trip-up1");
+
+        var tripId = (await (await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("N", "C", null, null, null)))
+            .Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson))!.Value!.Id;
+
+        var put = new UpdateTripRequest(
+            Name: "New",
+            City: "HCMC",
+            Country: "VN",
+            StartDate: null,
+            EndDate: null,
+            Visibility: TripVisibility.Private);
+
+        var response = await Client.PutAsJsonAsync($"/api/v1/trips/{tripId}", put);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson);
+        result!.Value!.Name.Should().Be("New");
+        result.Value.City.Should().Be("HCMC");
+    }
+
+    [Fact]
+    public async Task UpdateTrip_SetPrivate_ClearsShareToken()
+    {
+        await RegisterAndLoginAsync(email: "trip-up2@test.com", username: "trip-up2");
+
+        var tripId = (await (await Client.PostAsJsonAsync("/api/v1/trips",
+                new CreateTripRequest("N", "C", null, null, null, TripVisibility.PublicLink)))
+            .Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson))!.Value!.Id;
+
+        var put = new UpdateTripRequest("N", "C", null, null, null, TripVisibility.Private);
+        await Client.PutAsJsonAsync($"/api/v1/trips/{tripId}", put);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var trip = await db.Trips.SingleAsync(t => t.Id == tripId);
+        trip.ShareToken.Should().BeNull();
+        trip.Visibility.Should().Be(Entities.TripVisibility.Private);
+    }
+
+    [Fact]
+    public async Task UpdateTrip_NotFound_Returns404()
+    {
+        await RegisterAndLoginAsync(email: "trip-up3@test.com", username: "trip-up3");
+        var put = new UpdateTripRequest("N", "C", null, null, null, TripVisibility.Private);
+        var response = await Client.PutAsJsonAsync($"/api/v1/trips/{Guid.NewGuid()}", put);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task UpdateTrip_OtherUser_Returns404()
+    {
+        await RegisterAndLoginAsync(email: "trip-up4a@test.com", username: "trip-up4a");
+        var tripId = (await (await Client.PostAsJsonAsync("/api/v1/trips", new CreateTripRequest("N", "C", null, null, null)))
+            .Content.ReadFromJsonAsync<Result<TripDetailResponse>>(ApiJson))!.Value!.Id;
+
+        Client.DefaultRequestHeaders.Clear();
+        await RegisterAndLoginAsync(email: "trip-up4b@test.com", username: "trip-up4b");
+
+        var put = new UpdateTripRequest("H", "C", null, null, null, TripVisibility.Private);
+        var response = await Client.PutAsJsonAsync($"/api/v1/trips/{tripId}", put);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}


### PR DESCRIPTION
## Summary

- **Plan 3:** Trips CRUD, places on trips, share token, anonymous `GET /trips/shared/{token}`, shared DTOs, API tests.
- **Blazor:** login/register, trips pages, JWT `HttpClient`, CORS.
- **Merged `main`:** integrates Places API (Plan 2) already on `main` (Testcontainers, `UpdatePlace`, …).

## Conflict resolution

- `EndpointExtensions.cs`: Places route order from `main` + all Trips routes.
- `CopyPlace.cs`: documentation comment from `main`; new copies have no photos (no `LoadAsync`).
- `GetNearbyPlaces.cs`: `radiusKm` bounds validation (0–500) from `main`.

## Test plan

- [x] `dotnet test` — **50** passed after merge.