### PR TITLE
feat(e2e): Playwright suite and Plan 4 docs

### DIFF
--- a/docs/superpowers/plans/2026-04-18-04-e2e-playwright.md
+++ b/docs/superpowers/plans/2026-04-18-04-e2e-playwright.md
@@ -52,15 +52,15 @@ my-places/
 
 ## Task 1: Scaffold `e2e/` project
 
-- [ ] `cd e2e && npm init -y` (or pnpm) and add `@playwright/test`.
+- [x] `cd e2e && npm init -y` (or pnpm) and add `@playwright/test`.
 
-- [ ] `npx playwright install` (document Chromium-only for CI to save time).
+- [x] `npx playwright install` (document Chromium-only for CI to save time).
 
-- [ ] Add `playwright.config.ts` with `testDir: './specs'`, reasonable `timeout`, `trace: 'on-first-retry'`.
+- [x] Add `playwright.config.ts` with `testDir: './specs'`, reasonable `timeout`, `trace: 'on-first-retry'`.
 
-- [ ] Add `.gitignore` under `e2e/` for `test-results/`, `playwright-report/`, `blob-report/`.
+- [x] Add `.gitignore` under `e2e/` for `test-results/`, `playwright-report/`, `blob-report/`.
 
-- [ ] Root or `e2e/README.md` one paragraph: how to run (`E2E_BASE_URL=... npm test`), prerequisite “API + Client running”.
+- [x] Root or `e2e/README.md` one paragraph: how to run (`E2E_BASE_URL=... npm test`), prerequisite “API + Client running”.
 
 - [ ] Commit: `chore(e2e): add Playwright scaffold`
 
@@ -68,7 +68,7 @@ my-places/
 
 ## Task 2: Smoke spec
 
-- [ ] `smoke.spec.ts`: `page.goto('/')` (or `/login`) — expect HTTP 200 and visible shell (title, nav, or login form).
+- [x] `smoke.spec.ts`: `page.goto('/')` (or `/login`) — expect HTTP 200 and visible shell (title, nav, or login form).
 
 - [ ] Commit: `test(e2e): smoke spec`
 
@@ -76,9 +76,9 @@ my-places/
 
 ## Task 3: Auth spec
 
-- [ ] Flow: register new user → assert redirect or success UI → login (if separate) → assert authenticated marker (e.g. nav shows Trips).
+- [x] Flow: register new user → assert redirect or success UI → login (if separate) → assert authenticated marker (e.g. nav shows Trips).
 
-- [ ] Use stable `data-testid` on critical buttons/inputs in Blazor (Plan 3 / follow-up) — prefer testids over fragile CSS.
+- [x] Use stable `data-testid` on critical buttons/inputs in Blazor (Plan 3 / follow-up) — prefer testids over fragile CSS.
 
 - [ ] Commit: `test(e2e): auth register and login`
 
@@ -86,11 +86,11 @@ my-places/
 
 ## Task 4: Trips + shared link spec
 
-- [ ] Logged-in: create a place (if UI exists) or use API from `request` fixture with saved token — **prefer UI** if Plan 3 includes place creation; otherwise document “seed via API” using `API.request` in Playwright.
+- [x] Logged-in: create a place (if UI exists) or use API from `request` fixture with saved token — **prefer UI** if Plan 3 includes place creation; otherwise document “seed via API” using `API.request` in Playwright.
 
-- [ ] Create trip, add place to trip, invoke share, read `SharePath` / URL from UI.
+- [x] Create trip, add place to trip, invoke share, read `SharePath` / URL from UI.
 
-- [ ] New browser context **without** storage: open shared URL, assert trip name and at least one place visible.
+- [x] New browser context **without** storage: open shared URL, assert trip name and at least one place visible.
 
 - [ ] Commit: `test(e2e): trip share flow and anonymous shared view`
 
@@ -98,9 +98,9 @@ my-places/
 
 ## Task 5: Playwright MCP (documentation only in repo)
 
-- [ ] In `e2e/README.md` (or this plan §Verification): short list of MCP-driven checks agents should run before claiming Plan 3/4 done (open shared link, screenshot on failure).
+- [x] In `e2e/README.md` (or this plan §Verification): short list of MCP-driven checks agents should run before claiming Plan 3/4 done (open shared link, screenshot on failure).
 
-- [ ] No MCP config in-repo required (lives in Cursor user MCP settings).
+- [x] No MCP config in-repo required (lives in Cursor user MCP settings).
 
 - [ ] Commit: `docs(e2e): document Playwright MCP verification`
 
@@ -108,9 +108,9 @@ my-places/
 
 ## Task 6: CI (optional but recommended)
 
-- [ ] GitHub Action job: services or steps to start Postgres if API self-hosts in CI; **simplest path** for MVP: job `workflow_dispatch` only, or skip CI until deploy story exists.
+- [x] GitHub Action job: services or steps to start Postgres if API self-hosts in CI; **simplest path** for MVP: job `workflow_dispatch` only, or skip CI until deploy story exists. _(Không thêm workflow; PR chạy E2E local — `e2e/README.md`.)_
 
-- [ ] If full CI is deferred, document “local + PR manual” in README.
+- [x] If full CI is deferred, document “local + PR manual” in README.
 
 - [ ] Commit (if implemented): `ci: add optional e2e workflow`
 

--- a/docs/superpowers/plans/README.md
+++ b/docs/superpowers/plans/README.md
@@ -9,7 +9,7 @@
 | 1 | [2026-04-18-01-solution-setup.md](2026-04-18-01-solution-setup.md) | ✅ Done | Solution, EF Core entities, Auth (JWT + Google), Result Pattern |
 | 2 | [2026-04-18-02-places-api.md](2026-04-18-02-places-api.md) | ✅ Done | Places API + Blazor Client |
 | 3 | [2026-04-18-03-trips-api.md](2026-04-18-03-trips-api.md) | ✅ Done | Trips API + Blazor Client |
-| 4 | [2026-04-18-04-e2e-playwright.md](2026-04-18-04-e2e-playwright.md) | ⏳ Pending (ready) | E2E Playwright (repo) + MCP verification |
+| 4 | [2026-04-18-04-e2e-playwright.md](2026-04-18-04-e2e-playwright.md) | ✅ Done | E2E Playwright (repo) + MCP verification |
 | 5 | _(chưa viết)_ | ⏳ Pending | Photos (SAS upload flow + client-side resize) |
 | 6 | _(chưa viết)_ | ⏳ Pending | Social (Follow, Search Users, Feed) |
 | 7 | _(chưa viết)_ | ⏳ Pending | Dashboard + Azure Deploy |
@@ -87,7 +87,7 @@ Plan 7 (Dashboard + Deploy) ← depends on Plans 1–3, 5–6 (E2E optional but 
 - [x] **Plan 1** — Solution Setup & Core Infrastructure → dùng `superpowers:subagent-driven-development`
 - [x] **Plan 2** — Places API + Blazor Client → PR #32
 - [x] **Plan 3** — Trips API + Blazor Client → [2026-04-18-03-trips-api.md](2026-04-18-03-trips-api.md)
-- [ ] **Plan 4** — E2E Playwright + MCP verification → [2026-04-18-04-e2e-playwright.md](2026-04-18-04-e2e-playwright.md) _(bước tiếp theo)_
+- [x] **Plan 4** — E2E Playwright + MCP verification → [2026-04-18-04-e2e-playwright.md](2026-04-18-04-e2e-playwright.md) → thư mục [e2e/](../../../e2e/)
 - [ ] **Plan 5** — Photos (SAS upload + client-side resize) _(chưa viết plan chi tiết)_
 - [ ] **Plan 6** — Social (Follow, Search, Feed) _(chưa viết plan chi tiết)_
 - [ ] **Plan 7** — Dashboard + Azure Deploy _(chưa viết plan chi tiết)_

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,39 @@
+# My Places — Playwright E2E
+
+End-to-end tests against the Blazor WASM client (`E2E_BASE_URL`, default `http://localhost:5178`) and the ASP.NET API (`E2E_API_BASE_URL`, default `http://localhost:5160`). The API must match the client’s `wwwroot/appsettings.Development.json` `ApiBaseUrl`.
+
+## Prerequisites
+
+1. **PostgreSQL** — from repo root: `docker compose up -d` (port `5434`, see `docker-compose.yml` and `src/MyPlaces.Api/appsettings.Development.json`).
+2. **API** — `dotnet run --project src/MyPlaces.Api` (default `http://localhost:5160`).
+3. **Client** — `dotnet run --project src/MyPlaces.Client` (default `http://localhost:5178`).
+4. **Browsers** — once: `cd e2e && npx playwright install chromium` (use `--with-deps` on Linux CI if you run tests there yourself).
+
+## Run
+
+```bash
+cd e2e
+npm install
+npx playwright test
+```
+
+Optional: `npx playwright test --ui` for the Playwright UI, or set `E2E_BASE_URL` / `E2E_API_BASE_URL` if your dev ports differ.
+
+## Before opening a PR
+
+Run the full stack locally, then `cd e2e && npx playwright test` and ensure all tests pass. This repo does **not** run Playwright on GitHub Actions; reviewers rely on authors running E2E locally.
+
+## Playwright MCP (Cursor)
+
+For quick manual verification after UI changes (complements this suite, does not replace it):
+
+- Open the app at the same `E2E_BASE_URL` as above.
+- Run smoke: load `/login`, confirm the Login heading and form.
+- After a share flow, open the shared URL in a clean session and confirm trip title and places list.
+- On failures, capture a screenshot or trace for the PR description.
+
+MCP server configuration stays in your Cursor user settings, not in this repository.
+
+## Relation to `dotnet test`
+
+API contract and ownership rules remain covered by `MyPlaces.Api.Tests` (Testcontainers). These specs focus on browser routing, auth storage, and trip/share UX.

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "my-places-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "my-places-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "my-places-e2e",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:ui": "playwright test --ui"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@playwright/test';
+
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:5178';
+
+export default defineConfig({
+  testDir: './specs',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  trace: 'on-first-retry',
+  timeout: 90_000,
+  expect: { timeout: 20_000 },
+  use: {
+    baseURL,
+    navigationTimeout: 45_000,
+    actionTimeout: 15_000,
+  },
+});

--- a/e2e/specs/auth.spec.ts
+++ b/e2e/specs/auth.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test('register then land on trips', async ({ page }) => {
+  const suffix = Date.now();
+  const email = `e2e.${suffix}@example.com`;
+  const username = `e2euser${suffix}`;
+
+  await page.goto('/register');
+  await expect(page.getByRole('heading', { name: 'Register' })).toBeVisible();
+
+  await page.getByTestId('register-email').fill(email);
+  await page.getByTestId('register-username').fill(username);
+  await page.getByTestId('register-display-name').fill('E2E User');
+  await page.getByTestId('register-password').fill('E2etest1');
+  await page.getByTestId('register-submit').click();
+
+  await expect(page).toHaveURL(/\/trips$/);
+  await expect(page.getByTestId('trips-heading')).toBeVisible();
+});

--- a/e2e/specs/env.ts
+++ b/e2e/specs/env.ts
@@ -1,0 +1,5 @@
+/** API origin (no trailing slash). Must match client `ApiBaseUrl` in Development. */
+export function apiBaseUrl(): string {
+  const raw = process.env.E2E_API_BASE_URL ?? 'http://localhost:5160';
+  return raw.replace(/\/$/, '');
+}

--- a/e2e/specs/smoke.spec.ts
+++ b/e2e/specs/smoke.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('login page loads', async ({ page }) => {
+  const res = await page.goto('/login');
+  expect(res?.ok()).toBeTruthy();
+  await expect(page.getByRole('heading', { name: 'Login' })).toBeVisible();
+  await expect(page.getByTestId('login-email')).toBeVisible();
+});

--- a/e2e/specs/trips.spec.ts
+++ b/e2e/specs/trips.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import { apiBaseUrl } from './env';
+
+interface ApiResult<T> {
+  isSuccess: boolean;
+  value?: T;
+  error?: string;
+}
+
+test('create trip, add place via API, share, view as anonymous', async ({ page, browser, request }) => {
+  const suffix = Date.now();
+  const email = `e2e.trip.${suffix}@example.com`;
+  const username = `e2etrip${suffix}`;
+  const placeName = `E2E Place ${suffix}`;
+  const tripName = `E2E Trip ${suffix}`;
+  const api = apiBaseUrl();
+
+  await page.goto('/register');
+  await expect(page.getByRole('heading', { name: 'Register' })).toBeVisible();
+  await page.getByTestId('register-email').fill(email);
+  await page.getByTestId('register-username').fill(username);
+  await page.getByTestId('register-display-name').fill('E2E Trip User');
+  await page.getByTestId('register-password').fill('E2etest1');
+  await page.getByTestId('register-submit').click();
+  await expect(page).toHaveURL(/\/trips$/);
+
+  const token = await page.evaluate(() => localStorage.getItem('myplaces.jwt'));
+  expect(token, 'JWT should be stored after register').toBeTruthy();
+
+  const placeResp = await request.post(`${api}/api/v1/places`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      name: placeName,
+      address: '1 Test Street',
+      city: 'Testville',
+      country: null,
+      latitude: null,
+      longitude: null,
+      note: null,
+    },
+  });
+  expect(placeResp.ok(), await placeResp.text()).toBeTruthy();
+  const placeBody = (await placeResp.json()) as ApiResult<{ id: string }>;
+  expect(placeBody.isSuccess, placeBody.error).toBeTruthy();
+  expect(placeBody.value?.id).toBeTruthy();
+
+  await page.getByTestId('trips-new-link').click();
+  await expect(page).toHaveURL(/\/trips\/new$/);
+  await page.getByTestId('trip-field-name').fill(tripName);
+  await page.getByTestId('trip-field-city').fill('Hanoi');
+  await page.getByTestId('trip-save').click();
+
+  await expect(page).toHaveURL(/\/trips\/[0-9a-f-]{36}$/i);
+  await expect(page.getByTestId('trip-detail-title')).toHaveText(tripName);
+
+  await page.getByTestId('trip-place-select').selectOption(placeBody.value!.id!);
+  await page.getByTestId('trip-add-place-button').click();
+  await expect(page.getByText(`${placeName} — Testville`)).toBeVisible();
+
+  await page.getByTestId('trip-share-toggle').click();
+  const shareLink = page.getByTestId('shared-trip-open-link');
+  await expect(shareLink).toBeVisible();
+  const href = await shareLink.getAttribute('href');
+  expect(href).toBeTruthy();
+
+  const anon = await browser.newContext();
+  const anonPage = await anon.newPage();
+  await anonPage.goto(href!);
+  await expect(anonPage.getByTestId('shared-trip-heading')).toHaveText(tripName);
+  await expect(anonPage.getByTestId('shared-trip-place-list')).toContainText(placeName);
+  await anon.close();
+});

--- a/src/MyPlaces.Client/Pages/Login.razor
+++ b/src/MyPlaces.Client/Pages/Login.razor
@@ -11,13 +11,13 @@
 <EditForm Model="_model" OnValidSubmit="SubmitAsync">
     <p>
         <label>Email</label>
-        <InputText @bind-Value="_model.Email" class="form-control" />
+        <InputText @bind-Value="_model.Email" class="form-control" data-testid="login-email" />
     </p>
     <p>
         <label>Password</label>
-        <InputText type="password" @bind-Value="_model.Password" class="form-control" />
+        <InputText type="password" @bind-Value="_model.Password" class="form-control" data-testid="login-password" />
     </p>
-    <button type="submit" class="btn btn-primary">Sign in</button>
+    <button type="submit" class="btn btn-primary" data-testid="login-submit">Sign in</button>
 </EditForm>
 @if (!string.IsNullOrEmpty(_error))
 {

--- a/src/MyPlaces.Client/Pages/Register.razor
+++ b/src/MyPlaces.Client/Pages/Register.razor
@@ -11,21 +11,21 @@
 <EditForm Model="_model" OnValidSubmit="SubmitAsync">
     <p>
         <label>Email</label>
-        <InputText @bind-Value="_model.Email" class="form-control" />
+        <InputText @bind-Value="_model.Email" class="form-control" data-testid="register-email" />
     </p>
     <p>
         <label>Username</label>
-        <InputText @bind-Value="_model.Username" class="form-control" />
+        <InputText @bind-Value="_model.Username" class="form-control" data-testid="register-username" />
     </p>
     <p>
         <label>Display name</label>
-        <InputText @bind-Value="_model.DisplayName" class="form-control" />
+        <InputText @bind-Value="_model.DisplayName" class="form-control" data-testid="register-display-name" />
     </p>
     <p>
         <label>Password</label>
-        <InputText type="password" @bind-Value="_model.Password" class="form-control" />
+        <InputText type="password" @bind-Value="_model.Password" class="form-control" data-testid="register-password" />
     </p>
-    <button type="submit" class="btn btn-primary">Create account</button>
+    <button type="submit" class="btn btn-primary" data-testid="register-submit">Create account</button>
 </EditForm>
 @if (!string.IsNullOrEmpty(_error))
 {

--- a/src/MyPlaces.Client/Pages/Trips/SharedTripView.razor
+++ b/src/MyPlaces.Client/Pages/Trips/SharedTripView.razor
@@ -14,7 +14,7 @@ else if (!string.IsNullOrEmpty(_error))
 }
 else if (_trip is not null)
 {
-    <h1>@_trip.Name</h1>
+    <h1 data-testid="shared-trip-heading">@_trip.Name</h1>
     <p>@_trip.City @(_trip.Country is not null ? $", {_trip.Country}" : "")</p>
 
     <h2>Places</h2>
@@ -24,7 +24,7 @@ else if (_trip is not null)
     }
     else
     {
-        <ul class="list-group">
+        <ul class="list-group" data-testid="shared-trip-place-list">
             @foreach (var tp in _trip.Places)
             {
                 <li class="list-group-item">@tp.Place.Name — @tp.Place.City</li>

--- a/src/MyPlaces.Client/Pages/Trips/TripDetail.razor
+++ b/src/MyPlaces.Client/Pages/Trips/TripDetail.razor
@@ -15,11 +15,11 @@ else if (!string.IsNullOrEmpty(_error))
 }
 else if (_trip is not null)
 {
-    <h1>@_trip.Name</h1>
+    <h1 data-testid="trip-detail-title">@_trip.Name</h1>
     <p>@_trip.City @(_trip.Country is not null ? $", {_trip.Country}" : "")</p>
     <p>
         <a class="btn btn-outline-secondary" href="trips/@TripId/edit">Edit</a>
-        <button type="button" class="btn btn-outline-primary" @onclick="ToggleShareAsync">Share / unshare</button>
+        <button type="button" class="btn btn-outline-primary" data-testid="trip-share-toggle" @onclick="ToggleShareAsync">Share / unshare</button>
     </p>
     @if (_shareInfo is not null)
     {
@@ -28,7 +28,7 @@ else if (_trip is not null)
             @if (!string.IsNullOrEmpty(_shareInfo.SharePath))
             {
                 <div><strong>Path:</strong> @_shareInfo.SharePath</div>
-                <div><strong>Open:</strong> <a href="@($"{Nav.BaseUri.TrimEnd('/')}{_shareInfo.SharePath}")">@($"{Nav.BaseUri.TrimEnd('/')}{_shareInfo.SharePath}")</a></div>
+                <div><strong>Open:</strong> <a data-testid="shared-trip-open-link" href="@($"{Nav.BaseUri.TrimEnd('/')}{_shareInfo.SharePath}")">@($"{Nav.BaseUri.TrimEnd('/')}{_shareInfo.SharePath}")</a></div>
             }
         </div>
     }
@@ -37,14 +37,14 @@ else if (_trip is not null)
     @if (_myPlaces is not null && _myPlaces.Count > 0)
     {
         <div class="input-group mb-3" style="max-width: 28rem;">
-            <select class="form-select" @bind="_selectedPlaceId">
+            <select class="form-select" data-testid="trip-place-select" @bind="_selectedPlaceId">
                 <option value="">— add a place —</option>
                 @foreach (var p in _myPlaces)
                 {
                     <option value="@p.Id">@p.Name (@p.City)</option>
                 }
             </select>
-            <button class="btn btn-outline-primary" type="button" @onclick="AddPlaceAsync" disabled="@string.IsNullOrEmpty(_selectedPlaceId)">Add</button>
+            <button class="btn btn-outline-primary" type="button" data-testid="trip-add-place-button" @onclick="AddPlaceAsync" disabled="@string.IsNullOrEmpty(_selectedPlaceId)">Add</button>
         </div>
     }
 

--- a/src/MyPlaces.Client/Pages/Trips/TripEditor.razor
+++ b/src/MyPlaces.Client/Pages/Trips/TripEditor.razor
@@ -21,32 +21,32 @@ else
     <EditForm Model="_model" OnValidSubmit="SaveAsync">
         <p>
             <label>Name</label>
-            <InputText @bind-Value="_model.Name" class="form-control" />
+            <InputText @bind-Value="_model.Name" class="form-control" data-testid="trip-field-name" />
         </p>
         <p>
             <label>City</label>
-            <InputText @bind-Value="_model.City" class="form-control" />
+            <InputText @bind-Value="_model.City" class="form-control" data-testid="trip-field-city" />
         </p>
         <p>
             <label>Country</label>
-            <InputText @bind-Value="_model.Country" class="form-control" />
+            <InputText @bind-Value="_model.Country" class="form-control" data-testid="trip-field-country" />
         </p>
         <p>
             <label>Start</label>
-            <InputDate @bind-Value="_model.StartDate" class="form-control" Type="InputDateType.Date" />
+            <InputDate @bind-Value="_model.StartDate" class="form-control" Type="InputDateType.Date" data-testid="trip-field-start" />
         </p>
         <p>
             <label>End</label>
-            <InputDate @bind-Value="_model.EndDate" class="form-control" Type="InputDateType.Date" />
+            <InputDate @bind-Value="_model.EndDate" class="form-control" Type="InputDateType.Date" data-testid="trip-field-end" />
         </p>
         <p>
             <label>Visibility</label>
-            <InputSelect @bind-Value="_model.Visibility" class="form-control">
+            <InputSelect @bind-Value="_model.Visibility" class="form-control" data-testid="trip-field-visibility">
                 <option value="@TripVisibility.Private">Private</option>
                 <option value="@TripVisibility.PublicLink">Public link</option>
             </InputSelect>
         </p>
-        <button type="submit" class="btn btn-primary">Save</button>
+        <button type="submit" class="btn btn-primary" data-testid="trip-save">Save</button>
         <a class="btn btn-link" href="trips">Cancel</a>
     </EditForm>
 }

--- a/src/MyPlaces.Client/Pages/Trips/TripList.razor
+++ b/src/MyPlaces.Client/Pages/Trips/TripList.razor
@@ -5,8 +5,8 @@
 
 <PageTitle>Trips</PageTitle>
 
-<h1>My trips</h1>
-<p><a class="btn btn-primary" href="trips/new">New trip</a></p>
+<h1 data-testid="trips-heading">My trips</h1>
+<p><a class="btn btn-primary" href="trips/new" data-testid="trips-new-link">New trip</a></p>
 
 @if (_loading)
 {


### PR DESCRIPTION
Add Playwright E2E under e2e/ (smoke, register→trips, trip flow with API-seeded place and anonymous shared view).

Wire data-testid on Login, Register, and Trips pages for stable selectors. Document local run, E2E_BASE_URL/E2E_API_BASE_URL, PR checklist (no CI E2E), and Playwright MCP notes in e2e/README.md. Mark Plan 4 complete in superpowers plan docs.